### PR TITLE
add arm64 arch target for macOS

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,14 @@
       "artifactName": "dbgate-mac-${version}.${ext}",
       "publish": [
         "github"
-      ]
+      ],
+      "target": {
+        "target": "default",
+        "arch": [
+          "arm64",
+          "x64"
+        ]
+      }
     },
     "linux": {
       "target": [


### PR DESCRIPTION
I haven't been able to test this out yet since I'm running into issues with building on Apple Silicon (unrelated to building *for* Apple Silicon)

Opening this as a reminder to myself to test this on an Intel laptop ☺️ 