### PR TITLE
fix: catch getViewTexts errors otherwise no structure can be seen

### DIFF
--- a/plugins/dbgate-plugin-mysql/src/backend/Analyser.js
+++ b/plugins/dbgate-plugin-mysql/src/backend/Analyser.js
@@ -79,8 +79,13 @@ class Analyser extends DatabaseAnalyser {
   async getViewTexts(allViewNames) {
     const res = {};
     for (const viewName of this.getRequestedViewNames(allViewNames)) {
-      const resp = await this.driver.query(this.pool, `SHOW CREATE VIEW \`${viewName}\``);
-      res[viewName] = resp.rows[0]['Create View'];
+      try {
+        const resp = await this.driver.query(this.pool, `SHOW CREATE VIEW \`${viewName}\``);
+        res[viewName] = resp.rows[0]['Create View'];
+      } catch(err) {
+        console.log('ERROR', err);
+        res[viewName] = `${err}`;
+      }
     }
     return res;
   }


### PR DESCRIPTION
if somehow SHOW CREATE VIEW fails (invalid refs, permissions) it throws an
error and no structure is shown at all.