### PR TITLE
Fixes misplaced tab close icon

### DIFF
--- a/packages/web/src/widgets/TabsPanel.svelte
+++ b/packages/web/src/widgets/TabsPanel.svelte
@@ -540,6 +540,7 @@
   .file-name {
     margin-left: 5px;
     white-space: nowrap;
+    flex-grow: 1;
   }
   .close-button {
     margin-left: 5px;


### PR DESCRIPTION
To fix #260
I think there's no need to change the close button to `close-button-right` since the `file-name` span would flex correctly same as `db-name`