### PR TITLE
Set default database as auth source for mongodb connection

### DIFF
--- a/plugins/dbgate-plugin-mongo/src/backend/driver.js
+++ b/plugins/dbgate-plugin-mongo/src/backend/driver.js
@@ -62,6 +62,9 @@ const driver = {
     const options = {
       useUnifiedTopology: true,
     };
+    if (database) {
+      options.authSource = database;
+    }
     if (ssl) {
       options.tls = true;
       options.tlsCAFile = ssl.ca;


### PR DESCRIPTION
This change may break some configurations, but it seems that the default database is used for authentication also on other drivers. On the other hand, without that change it's not possible to connect to a mongodb where the authdb isn't the "admin" db.