### PR TITLE
Migrate appdata to platform-specific locations

### DIFF
--- a/app/src/electron.js
+++ b/app/src/electron.js
@@ -20,12 +20,38 @@ const { settings } = require('cluster');
 
 // require('@electron/remote/main').initialize();
 
-const configRootPath = path.join(app.getPath('userData'), 'config-root.json');
+const datadir = path.join(app.getPath('appData'), app.getName());
+migrateDataDir();
+const configRootPath = path.join(datadir, 'config-root.json');
 let initialConfig = {};
 let apiLoaded = false;
 let mainModule;
 // let getLogger;
 // let loadLogsContent;
+
+// Put electron data in sub-folder
+const electrondir = path.join(datadir, 'electron');
+app.setPath('userData', path.join(datadir, 'electron'));
+
+function migrateDataDir() {
+  const settingsPath = path.join(datadir, 'settings.json');
+  const oldDatadir = path.join(os.homedir(), '.dbgate');
+  const oldSettingsPath = path.join(oldDatadir, 'settings.json');
+  if (fs.existsSync(oldSettingsPath) && !fs.existsSync(settingsPath)) {
+    // Move Electron files to subdir
+    for (const file of fs.readdirSync(datadir)) {
+      if (file === 'config-root.json') {
+        continue;
+      }
+      fs.renameSync(path.join(datadir, file), path.join(electrondir, file));
+    }
+    // Move appdata
+    for (const file of fs.readdirSync(oldDatadir)) {
+      fs.renameSync(path.join(oldDatadir, file), path.join(datadir, file));
+    }
+    fs.rmSync(oldDatadir);
+  }
+}
 
 const isMac = () => os.platform() == 'darwin';
 
@@ -267,7 +293,6 @@ function fillMissingSettings(value) {
 function createWindow() {
   let settingsJson = {};
   try {
-    const datadir = path.join(os.homedir(), '.dbgate');
     settingsJson = fillMissingSettings(
       JSON.parse(fs.readFileSync(path.join(datadir, 'settings.json'), { encoding: 'utf-8' }))
     );


### PR DESCRIPTION
Would love to have this implemented, though if you insist on not changing, then I suppose it is what it is.

Currently I'm just running a migration in `electron.js`, moving `~/.dbgate` to `<userData>/dbgate` and `<userData>/*` to `<userData>/electron/*` (except `config-root.json`)

I'm guessing that ideally the migration would run from `packages/api/src/utility/directories.js`, but it needs to run in `electron.js` before `createWindow()`. Could `api` be imported before `createWindow()`, or does it have to be deferred?

I wasn't able to test it because because `yarn install` fails:
```
➤ YN0009: │ dbgate-all@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/gs/3qcm1mc918s08sxvkj6zj2rr0000gp/T/xfs-a886ecd0/build.log)
➤ YN0000: └ Completed in 15s 418ms
➤ YN0000: Failed with errors in 16s 210ms
```

Closes #459