### PR TITLE
Fixes missing toolstrip and adds up to 200% zoom to diagram view

### DIFF
--- a/packages/web/src/designer/Designer.svelte
+++ b/packages/web/src/designer/Designer.svelte
@@ -842,6 +842,26 @@
               text: `100 %`,
               onClick: changeStyleFunc('zoomKoef', 1),
             },
+            {
+              text: `120 %`,
+              onClick: changeStyleFunc('zoomKoef', 1.2),
+            },
+            {
+              text: `140 %`,
+              onClick: changeStyleFunc('zoomKoef', 1.4),
+            },
+            {
+              text: `160 %`,
+              onClick: changeStyleFunc('zoomKoef', 1.6),
+            },
+            {
+              text: `180 %`,
+              onClick: changeStyleFunc('zoomKoef', 1.8),
+            },
+            {
+              text: `200 %`,
+              onClick: changeStyleFunc('zoomKoef', 2),
+            },
           ],
         },
       ],

--- a/packages/web/src/tabs/DiagramTab.svelte
+++ b/packages/web/src/tabs/DiagramTab.svelte
@@ -27,6 +27,7 @@
   import ToolStripCommandButton from '../buttons/ToolStripCommandButton.svelte';
   import invalidateCommands from '../commands/invalidateCommands';
   import ToolStripSaveButton from '../buttons/ToolStripSaveButton.svelte';
+  import VerticalSplitter from "../elements/VerticalSplitter.svelte";
 
   export let tabid;
   export let conid;
@@ -100,7 +101,12 @@
 </script>
 
 <ToolStripContainer>
-  <DiagramDesigner value={$modelState.value || {}} {conid} {database} onChange={handleChange} menu={createMenu} />
+  <VerticalSplitter isSplitter={false}>
+    <svelte:fragment slot="1">
+      <DiagramDesigner value={$modelState.value || {}} {conid} {database} onChange={handleChange} menu={createMenu} />
+    </svelte:fragment>
+  </VerticalSplitter>
+  
   <svelte:fragment slot="toolstrip">
     <ToolStripCommandButton command="designer.arrange" />
     <ToolStripSaveButton idPrefix="diagram" />


### PR DESCRIPTION
On Linux I currently do not have any toolstrip for diagram view, nor am I able to use horizontal/vertical scrollbars (they don't exist), with this they all work again, tested on Linux.

Additionally this adds zoom factor up to 200% for the diagram designer as on high DPI displays, 100% can still be relatively small.