### PR TITLE
Fix - SQL export is using the wrong hour formatting

### DIFF
--- a/packages/web/src/modals/ExportDatabaseDumpModal.svelte
+++ b/packages/web/src/modals/ExportDatabaseDumpModal.svelte
@@ -24,7 +24,7 @@
   let pureFileName = null;
 
   function getDefaultFileName() {
-    return `${connection.database}-${dateFormat(new Date(), 'yyyy-MM-dd-hh-mm-ss')}.sql`;
+    return `${connection.database}-${dateFormat(new Date(), 'yyyy-MM-dd-HH-mm-ss')}.sql`;
   }
 
   onMount(async () => {


### PR DESCRIPTION
The formatting is incorrect, using 12-hours instead of 24-hours for exported files.

If this should be toggle-able by end users we likely need to add something to determine am/pm in the timestamp.
Ideally we just keep 24 hours to keep it simple.

This fixes https://github.com/dbgate/dbgate/issues/530