### PR TITLE
Update table view based on the selected postgres db

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,16 +16,22 @@ services:
     volumes:
       - dbgate-data:/root/.dbgate
     
-    # environment:
-    #   WEB_ROOT: /dbgate
+#    environment:
+#      WEB_ROOT: /dbgate
 
-      # CONNECTIONS: mssql
-      # LABEL_mssql: MS Sql
-      # SERVER_mssql: mssql
-      # USER_mssql: sa
-      # PORT_mssql: 1433
-      # PASSWORD_mssql: Pwd2020Db
-      # ENGINE_mssql: mssql@dbgate-plugin-mssql
+#      CONNECTIONS: mssql
+#      LABEL_mssql: MS Sql
+#      SERVER_mssql: mssql
+#      USER_mssql: sa
+#      PORT_mssql: 1433
+#      PASSWORD_mssql: Pwd2020Db
+#      ENGINE_mssql: mssql@dbgate-plugin-mssql
+
+#      CONNECTIONS: pg
+#
+#      LABEL_pg: Postgres
+#      URL_pg: postgres://postgres:postgres@postgres:5432/dbgate-test?sslmode=disable
+#      ENGINE_pg: postgres@dbgate-plugin-postgres
   # proxy:
   #   # image: nginx
   #   build: test/nginx
@@ -48,6 +54,17 @@ services:
   #     - ACCEPT_EULA=Y
   #     - SA_PASSWORD=Pwd2020Db
   #     - MSSQL_PID=Express
+
+#  postgres:
+#    environment:
+#      POSTGRES_DB: "dbgate-test"
+#      POSTGRES_PASSWORD: "postgres"
+#      POSTGRES_USER: "postgres"
+#      POSTGRES_HOST_AUTH_METHOD: "trust"
+#    image: postgres:13.1-alpine
+#    ports:
+#      - "5432:5432"
+#    restart: on-failure
 
 volumes:
   dbgate-data:

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableList.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableList.js
@@ -2,9 +2,10 @@ module.exports = `
 select infoTables.table_schema as "schema_name", infoTables.table_name as "pure_name"
 from information_schema.tables infoTables 
 where infoTables.table_type not like '%VIEW%' 
-  and ('tables:' || infoTables.table_schema || '.' ||  infoTables.table_name) =OBJECT_ID_CONDITION
-and infoTables.table_schema <> 'pg_catalog'
-and infoTables.table_schema <> 'information_schema'
-and infoTables.table_schema <> 'pg_internal'
-and infoTables.table_schema !~ '^pg_toast'
+    and infoTables.table_catalog = '#DATABASE#'
+    and ('tables:' || infoTables.table_schema || '.' ||  infoTables.table_name) = OBJECT_ID_CONDITION
+    and infoTables.table_schema <> 'pg_catalog'
+    and infoTables.table_schema <> 'information_schema'
+    and infoTables.table_schema <> 'pg_internal'
+    and infoTables.table_schema !~ '^pg_toast'
 `;


### PR DESCRIPTION
As far as I see, in case of Postgres plugin, dbgate `TABLES, VIEWS, FUNCTIONS` section not updated based on the selected postgres DB, but showing all the available table from all the databases within the postgres instance.

Adding the `#DATABASE#` filter into the tableList.sql this problem could solved.

@janproch Could you check this out? Should I update other queries with this WHERE clause too?