### PR TITLE
Pass signals in entrypoint.sh

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,4 +8,4 @@ then
   echo "$HOST_IP $HOST_DOMAIN" >> /etc/hosts
 fi
 
-node bundle.js --listen-api
+exec node bundle.js --listen-api


### PR DESCRIPTION
Replace `entrypoint.sh` process with `node` process in final command using `exec`.

This is to pass signals to the `node` process (e.g. SIGTERM upon stopping the container).
Currently signals are ignored, because `node` is executed as subprocess of the `entrypoint.sh`.

This will allow to speed up shutting down of the container.
