### PR TITLE
feat(plugin/redis): add username and tls to redis connection

### DIFF
--- a/plugins/dbgate-plugin-redis/src/backend/driver.js
+++ b/plugins/dbgate-plugin-redis/src/backend/driver.js
@@ -81,7 +81,7 @@ function splitCommandLine(str) {
 const driver = {
   ...driverBase,
   analyserClass: Analyser,
-  async connect({ server, port, password, database, useDatabaseUrl, databaseUrl, treeKeySeparator }) {
+  async connect({ server, port, user, password, database, useDatabaseUrl, databaseUrl, treeKeySeparator }) {
     let db = 0;
     let pool;
     if (useDatabaseUrl) {
@@ -91,9 +91,11 @@ const driver = {
       if (_.isNumber(database)) db = database;
       pool = new Redis({
         host: server,
+        username: user,
         port,
         password,
         db,
+        tls: {},
       });
       pool.__treeKeySeparator = treeKeySeparator || ':';
     }

--- a/plugins/dbgate-plugin-redis/src/frontend/driver.js
+++ b/plugins/dbgate-plugin-redis/src/frontend/driver.js
@@ -80,7 +80,7 @@ const driver = {
     if (values.useDatabaseUrl) {
       return ['databaseUrl', 'isReadOnly', 'treeKeySeparator'].includes(field);
     }
-    return ['server', 'port', 'password', 'isReadOnly', 'treeKeySeparator'].includes(field);
+    return ['server', 'user', 'port', 'password', 'isReadOnly', 'treeKeySeparator'].includes(field);
   },
 
   showConnectionTab: (field) => field == 'sshTunnel',


### PR DESCRIPTION
As now connection with username is possible (instead of using the generic default user)
we could use a username and tls to connect to redis, using the connection tab.

as describe here 
https://github.com/redis/ioredis/blob/9c175502b53b400a31bd8bddc8e9a469856bc820/README.md?plain=1#L897
I changed some parameters in the ioredis connection.

I hope it helps
Thanks