### PR TITLE
add API headers on upload call

### DIFF
--- a/packages/web/src/utility/uploadFiles.ts
+++ b/packages/web/src/utility/uploadFiles.ts
@@ -2,7 +2,7 @@ import { extensions } from '../stores';
 import { get } from 'svelte/store';
 import { canOpenByElectron, openElectronFileCore } from './openElectronFile';
 import getElectron from './getElectron';
-import resolveApi from './resolveApi';
+import resolveApi, { resolveApiHeaders } from './resolveApi';
 import { findFileFormat } from '../plugins/fileformats';
 import { showModal } from '../modals/modalTools';
 import ImportExportModal from '../modals/ImportExportModal.svelte';
@@ -46,6 +46,7 @@ export default function uploadFiles(files) {
     const fetchOptions = {
       method: 'POST',
       body: formData,
+      headers: resolveApiHeaders(),
     };
 
     const apiBase = resolveApi();


### PR DESCRIPTION
This is to resolve #626 which was identified as an issue where the JWT is not passed along with an upload request when password authentication is enabled.