### PR TITLE
fix: query editor on import/export screen overlaps with selector

### DIFF
--- a/packages/web/src/impexp/SourceTargetConfig.svelte
+++ b/packages/web/src/impexp/SourceTargetConfig.svelte
@@ -191,6 +191,7 @@
 
   .sqlwrap {
     position: relative;
+    z-index: 0;
     height: 100px;
     width: 20vw;
     margin-left: var(--dim-large-form-margin);


### PR DESCRIPTION
# Description
This PR fixes a visual issue with the query editor in the import/export screen. When selecting 'Query' as the source storage type, the query editor would overlap unnaturally with the selector.
This is caused by z-index contamination. Creating a new stacking context on the editor wrapper fixes this.

# Reproduction procedure
| Procedure | Screenshot |
|:-|:-:|
|1. Open the Import/Export screen. <br /> Then select 'Query' as the source storage type.| <img width="200" alt="image" src="https://github.com/dbgate/dbgate/assets/40572953/c1d40cce-1c1f-4881-a6cb-2ad603b56bd8"> |
| 2. Open Selector. <br /><br /> This happens with any selector. |  <img width="200" alt="image" src="https://github.com/dbgate/dbgate/assets/40572953/c13b4481-4aaf-4c54-83ee-8addc0fe1f34"> <br /><br />  <img width="200" alt="image" src="https://github.com/dbgate/dbgate/assets/40572953/6b37ddb1-7301-40fa-bfe9-eef8ce2cc2e0"> |
