### PR TITLE
fix(web): file menu save and save as not working

### DIFF
--- a/packages/web/src/utility/contextMenu.ts
+++ b/packages/web/src/utility/contextMenu.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { getContext, setContext } from 'svelte';
 import invalidateCommands from '../commands/invalidateCommands';
+import { runGroupCommand } from '../commands/runCommand';
 import { currentDropDownMenu, visibleCommandPalette } from '../stores';
 import getAsArray from './getAsArray';
 
@@ -98,8 +99,12 @@ function mapItem(item, commands) {
         text: item.text || command.menuName || command.toolbarName || command.name,
         keyText: command.keyText || command.keyTextFromGroup,
         onClick: () => {
-          if (command.getSubCommands) visibleCommandPalette.set(command);
-          else if (command.onClick) command.onClick();
+          if (command.isGroupCommand) {
+            runGroupCommand(command.group);
+          } else {
+            if (command.getSubCommands) visibleCommandPalette.set(command);
+            else if (command.onClick) command.onClick();
+          }
         },
         disabled: !command.enabled,
         hideDisabled: item.hideDisabled,


### PR DESCRIPTION
Closes #364

## Description
This pull request addresses an issue with saving via the File menu on both the web app and Windows Electron. It should be noted that the save function operated correctly on MacOS Electron.

The issue stemmed from differing processing methods triggered when the menu is clicked.

First, the Save command on the menu is defined as a group command.
https://github.com/dbgate/dbgate/blob/79d1b7893da37ad77fa9492db106d93300877472/app/src/mainMenuDefinition.js#L19-L20
https://github.com/dbgate/dbgate/blob/79d1b7893da37ad77fa9492db106d93300877472/packages/web/src/commands/stdCommands.ts#L386-L402

On MacOS Electron, the menu command processing checks whether the command is a group command and branches the process.
https://github.com/dbgate/dbgate/blob/79d1b7893da37ad77fa9492db106d93300877472/packages/web/src/commands/runCommand.ts#L9-L10

However, this did not work correctly in web applications and Windows Electron, as it tried to directly call onClick in the command.

I addressed this issue by implementing logic to check if it is a group command, similar to MacOS Electron.

## Reproduce Procedure
Environment:
Wep app (any OS) or Windows(Electron)

1. Open Query Editor
2. Menu File > Save (or Save As)