### PR TITLE
fix: Mac - shortcut for select all

### DIFF
--- a/app/src/electron.js
+++ b/app/src/electron.js
@@ -229,6 +229,9 @@ ipcMain.on('window-action', async (event, arg) => {
     case 'paste':
       mainWindow.webContents.paste();
       break;
+    case 'selectAll':
+      mainWindow.webContents.selectAll();
+      break;
   }
 });
 

--- a/app/src/mainMenuDefinition.js
+++ b/app/src/mainMenuDefinition.js
@@ -48,6 +48,7 @@ module.exports = ({ editMenu }) => [
           { command: 'edit.cut' },
           { command: 'edit.copy' },
           { command: 'edit.paste' },
+          { command: 'edit.selectAll' },
         ],
       }
     : null,

--- a/packages/web/src/commands/stdCommands.ts
+++ b/packages/web/src/commands/stdCommands.ts
@@ -835,6 +835,16 @@ registerCommand({
   onClick: () => getElectron().send('window-action', 'paste'),
 });
 
+registerCommand({
+  id: 'edit.selectAll',
+  category: 'Edit',
+  name: 'Select All',
+  keyText: 'CtrlOrCommand+A',
+  systemCommand: true,
+  testEnabled: () => getElectron() != null,
+  onClick: () => getElectron().send('window-action', 'selectAll'),
+});
+
 const electron = getElectron();
 if (electron) {
   electron.addEventListener('run-command', (e, commandId) => runCommand(commandId));


### PR DESCRIPTION
Closes #673 

## Description

This PR fixes a macOS keyboard shortcut for select all.
Add Select All to just macOS edit menu.

I checked the operation on MacOS and Windows (electron app and chrome) respectively. It appeared to be a bug that only occurred with Electron on MacOS.

I also checked Electron Issues and found that shortcuts sometimes do not work on Mac.
https://github.com/electron/electron/issues/3787

I have confirmed that adding the Select All shortcut to the menu solves the problem.
(I add a new menu to the Edit menu. This is for Electron. This means that the new menu item will also appear in Windows Electron.)

## Reproduction Procedure
(Exactly the same as an issue procedure)

Environment: MacOS Electron
1. Go to any input field
2. Write some text
3. Press Command + a to select whole text


