### PR TITLE
fix: download with auth header

### DIFF
--- a/packages/web/src/query/RunnerOutputFiles.svelte
+++ b/packages/web/src/query/RunnerOutputFiles.svelte
@@ -5,7 +5,7 @@
 
   import formatFileSize from '../utility/formatFileSize';
   import getElectron from '../utility/getElectron';
-  import resolveApi from '../utility/resolveApi';
+  import { downloadFromApi } from '../utility/exportFileTools';
   import useEffect from '../utility/useEffect';
 
   export let runnerId;
@@ -66,9 +66,10 @@
     <a
       slot="0"
       let:row
-      href={`${resolveApi()}/runners/data/${runnerId}/${row.name}`}
-      target="_blank"
-      rel="noopener noreferrer"
+      href="#"
+      on:click={() => {
+        downloadFromApi(`runners/data/${runnerId}/${row.name}`, row.name);
+      }}
     >
       download
     </a>


### PR DESCRIPTION
fixes #503, fixes #636

## Description
This PR fixes an identified issue where the JWT is not passed with a download request when password authentication is enabled.

Not only have the previously reported issues been fixed, but also the code where similar bugs occur due to the same coding.
There were four.

## Reproduction Procedure
Environment: Docker or Web

### Prepare Procedure
Please set the `env` values as follows before trying each case to enable authentication.
(The value itself can be anything.)
```
LOGINS=test
LOGIN_PASSWORD_test=test
```

### case 1. Export Wizard
1. Right click on database.
2. Select `Export wizard`, then Open `Export / Import` Screen.
3. Select any `Souce configuration`.
4. Select any file as `Target configuration`.
5. Run.
6. Click `download` from OUTPUT files.

### case 2. Quick Export
Quick Export is an export that does not use the wizard. can be accessed from the context menu or from the bottom menu of the editable data grid.

1. Right click on Tables.
2. `Export` > select any file (ex. `SQL`).

### case 3. Backup/Export SQL dump
1. Right click on database.
2. Select `Backup/Export SQL dump`, then Open `Export database dump` modal.
3. Click `Set download`.
4. Click `Run export`.
5. Click `Download SQL`.

### case 4. Others
Other features that has download process are below ones.
The features call the same function, `saveFileToDisk`.

- Database Diff Report (Compare with -> Report)
- Export Map (Open Cell Data View, then `Export to HTML file` from contextmenu)
- Export Chart (Open Chat, then `Export` from contextmenu)
- Export Diagram (Open Diagram, then `Export diagram` from bottom of menu.)