### PR TITLE
fix(app): Encoding error when opening Unicode query files

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,6 +31,7 @@
     "diff": "^5.0.0",
     "diff2html": "^3.4.13",
     "file-selector": "^0.2.4",
+    "iconv-lite": "^0.6.3",
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.0.1",
     "localforage": "^1.9.0",

--- a/packages/web/src/utility/openElectronFile.ts
+++ b/packages/web/src/utility/openElectronFile.ts
@@ -55,9 +55,14 @@ function getFileEncoding(filePath, fs) {
   if (!e && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) e = 'utf8';
   if (!e && buf[0] === 0xfe && buf[1] === 0xff) e = 'utf16be';
   if (!e && buf[0] === 0xff && buf[1] === 0xfe) e = 'utf16le';
-  if (!e) e = 'ascii';
+  if (!e) e = 'utf8';
 
   return e;
+}
+
+function decodeFile(buf: Uint8Array, enc: string) {
+  const iconv = window.require('iconv-lite');
+  return iconv.decode(buf, enc);
 }
 
 function openElectronJsonLinesFile(filePath, parsed) {
@@ -115,7 +120,8 @@ export function openElectronFileCore(filePath, extensions) {
 
   if (nameLower.endsWith('.sql')) {
     const encoding = getFileEncoding(filePath, fs);
-    const data = fs.readFileSync(filePath, { encoding });
+    const buf = fs.readFileSync(filePath);
+    const data = decodeFile(buf, encoding);
 
     newQuery({
       title: parsed.name,


### PR DESCRIPTION
Closes #376, Closes #634, Closes #640

## Description

This is also noted in the following comment.
https://github.com/dbgate/dbgate/issues/376#issuecomment-1841314551

When the feature to determine the encoding from a file's Byte Order Mark (BOM) was added, the encoding was determined to be `ascii` if the encoding could not be determined from the BOM.

`utf-8` is compatible with `ascii` encoding, and if a file containing only `ascii` characters is saved in `utf-8`, the binaries will be equivalent.
However, unicode characters that can be handled by `utf-8` cannot be handled by `ascii`, resulting in garbled characters.
For this reason, I have changed the encoding to be judged as `utf-8` if the encoding cannot be determined from the BOM.

Also, the file decoding process has been changed to use `iconv-lite` for the following two reasons.
1. for files with BOM, non-BOM parts need to be decoded into characters.
2. `utf16be` is an encoding that is not supported by fs.readFileSync.

The module I added is a dependency of several existing packages, so it is already installed.