### PR TITLE
Adding env for parsing for trustServerCertificate connection value

### DIFF
--- a/packages/api/src/controllers/connections.js
+++ b/packages/api/src/controllers/connections.js
@@ -88,6 +88,7 @@ function getPortalCollections() {
       sslCertFilePassword: process.env[`SSL_CERT_FILE_PASSWORD_${id}`],
       sslKeyFile: process.env[`SSL_KEY_FILE_${id}`],
       sslRejectUnauthorized: process.env[`SSL_REJECT_UNAUTHORIZED_${id}`],
+      trustServerCertificate: process.env[`SSL_TRUST_CERTIFICATE_${id}`],
     }));
 
     logger.info({ connections: connections.map(pickSafeConnectionInfo) }, 'Using connections from ENV variables');


### PR DESCRIPTION
This PR adds a new environment variable `SSL_TRUST_CERTIFICATE_${id}` which is necessary to connect to a database that has a self signed cert via environment variables. It should resolve this issue https://github.com/dbgate/dbgate/issues/600 