### PR TITLE
Postgresql - Show proper types for Composite Types, Enums and Arrays

### DIFF
--- a/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
@@ -4,10 +4,10 @@ select
 	table_name as "pure_name", 
 	column_name as "column_name",
 	is_nullable as "is_nullable",
-    case
-			when (data_type = 'USER-DEFINED' OR data_type = 'ARRAY') then udt_name::regtype::text
-      else data_type
-     end
+    	case
+		when (data_type = 'USER-DEFINED' OR data_type = 'ARRAY') then udt_name::regtype::text
+		else data_type
+	end
 	as "data_type",
 	character_maximum_length as "char_max_length",
 	numeric_precision as "numeric_precision",

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
@@ -4,7 +4,11 @@ select
 	table_name as "pure_name", 
 	column_name as "column_name",
 	is_nullable as "is_nullable",
-	data_type as "data_type",
+    case
+			when (data_type = 'USER-DEFINED' OR data_type = 'ARRAY') then udt_name::regtype::text
+      else data_type
+     end
+	as "data_type",
 	character_maximum_length as "char_max_length",
 	numeric_precision as "numeric_precision",
 	numeric_scale as "numeric_scale",

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/columns.js
@@ -4,7 +4,7 @@ select
 	table_name as "pure_name", 
 	column_name as "column_name",
 	is_nullable as "is_nullable",
-    	case
+	case
 		when (data_type = 'USER-DEFINED' OR data_type = 'ARRAY') then udt_name::regtype::text
 		else data_type
 	end

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
@@ -2,7 +2,7 @@ module.exports = `
 select infoTables.table_schema as "schema_name", infoTables.table_name as "pure_name", 
     (
         select md5(string_agg(
-            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
+            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' coalesce(infoColumns.character_maximum_length, -1)::varchar(255) || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
                 || '|' || coalesce(infoColumns.numeric_precision, -1)::varchar(255) ,
             ',' order by infoColumns.ordinal_position
         )) as "hash_code_columns"

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
@@ -2,7 +2,7 @@ module.exports = `
 select infoTables.table_schema as "schema_name", infoTables.table_name as "pure_name", 
     (
         select md5(string_agg(
-            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' coalesce(infoColumns.character_maximum_length, -1)::varchar(255) || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
+            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
                 || '|' || coalesce(infoColumns.numeric_precision, -1)::varchar(255) ,
             ',' order by infoColumns.ordinal_position
         )) as "hash_code_columns"

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
@@ -2,7 +2,7 @@ module.exports = `
 select infoTables.table_schema as "schema_name", infoTables.table_name as "pure_name", 
     (
         select md5(string_agg(
-            infoColumns.column_name || '|' || infoColumns.data_type || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
+            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
                 || '|' || coalesce(infoColumns.numeric_precision, -1)::varchar(255) ,
             ',' order by infoColumns.ordinal_position
         )) as "hash_code_columns"

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
@@ -2,7 +2,7 @@ module.exports = `
 select infoTables.table_schema as "schema_name", infoTables.table_name as "pure_name", 
     (
         select md5(string_agg(
-            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
+            infoColumns.column_name || '|' || case when (infoColumns.data_type = 'USER-DEFINED' OR infoColumns.data_type = 'ARRAY') then infoColumns.udt_name::regtype::text else infoColumns.data_type end || '|' || infoColumns.is_nullable::varchar(255)  || '|' || coalesce(infoColumns.character_maximum_length, -1)::varchar(255) 
                 || '|' || coalesce(infoColumns.numeric_precision, -1)::varchar(255) ,
             ',' order by infoColumns.ordinal_position
         )) as "hash_code_columns"


### PR DESCRIPTION
This PR changes the Postgresql columns that are Composite Types, Enums or Arrays to show their proper type instead of `USER-DEFINED`.

Example:
```SQL
CREATE TYPE color AS ENUM ('red', 'green', 'blue');
CREATE TYPE condition AS ENUM ('new', 'old');
CREATE TYPE contact_type AS ENUM ('phone', 'email');

CREATE TYPE dimensions AS (
    width           NUMERIC,
    height          NUMERIC,
    depth           NUMERIC
);

CREATE TYPE contact AS (
    first_name      VARCHAR(255),
    last_name       VARCHAR(255),
    contact         VARCHAR(255),
    contact_type    contact_type
);

CREATE TABLE cars (
  id                SERIAL PRIMARY KEY, 
  brand             VARCHAR(255),
  model             VARCHAR(255),
  year              INT,
  color             color,
  condition         condition,
  parameters        size,
  contacts          contact[],
  gears_kmph        INT[]
);
```

Before:
<img width="1280" alt="before" src="https://github.com/dbgate/dbgate/assets/10557728/39755c96-432b-4b27-98e6-a16bbf037b13">

After:
<img width="1280" alt="after" src="https://github.com/dbgate/dbgate/assets/10557728/580b7c25-b284-4e91-b5a1-ccbf8fb7ed7a">
