### PR TITLE
feat: per-user permissions when using oauth

### DIFF
--- a/packages/api/src/controllers/auth.js
+++ b/packages/api/src/controllers/auth.js
@@ -137,7 +137,7 @@ module.exports = {
       return { error: 'Logins not configured' };
     }
     const foundLogin = logins.find(x => x.login == login);
-    if (foundLogin && foundLogin.password == password) {
+    if (foundLogin && foundLogin.password && foundLogin.password == password) {
       return {
         accessToken: jwt.sign({ login }, tokenSecret, { expiresIn: getTokenLifetime() }),
       };

--- a/packages/api/src/main.js
+++ b/packages/api/src/main.js
@@ -48,7 +48,7 @@ function start() {
   if (logins && process.env.BASIC_AUTH) {
     app.use(
       basicAuth({
-        users: _.fromPairs(logins.map(x => [x.login, x.password])),
+        users: _.fromPairs(logins.filter(x => x.password).map(x => [x.login, x.password])),
         challenge: true,
         realm: 'DbGate Web App',
       })

--- a/packages/api/src/utility/hasPermission.js
+++ b/packages/api/src/utility/hasPermission.js
@@ -39,7 +39,7 @@ function getLogins() {
       permissions: process.env.PERMISSIONS,
     });
   }
-  if (process.env.LOGINS) {
+  if (process.env.LOGINS || process.env.OAUTH_PERMISSIONS) {
     const logins = _.compact(process.env.LOGINS.split(',').map(x => x.trim()));
     for (const login of logins) {
       const password = process.env[`LOGIN_PASSWORD_${login}`];
@@ -50,6 +50,13 @@ function getLogins() {
           password,
           permissions,
         });
+      }
+      if (process.env.OAUTH_PERMISSIONS) {
+        res.push({
+          login,
+          password: null,
+          permissions,
+        })
       }
     }
   }


### PR DESCRIPTION
This PR enables the creation of permissions for users that do not have password-based login credentials defined. This is intended to be used with OAuth-based authentication, allowing for per-user authorization to be defined in dbgate, while allowing a 3rd party system to handle authentication.

I have added reference to an environment variable: `OAUTH_PERMISSIONS` which allows this authorization flow to be enabled. Without entering a truthy value for this environment variable, this workflow is disabled by default.