### PR TITLE
Added OAuth Allowed Groups Option

### DIFF
--- a/packages/api/src/controllers/auth.js
+++ b/packages/api/src/controllers/auth.js
@@ -90,6 +90,24 @@ module.exports = {
     ) {
       return { error: `Username ${login} not allowed to log in` };
     }
+
+    const groups = 
+      process.env.OAUTH_GROUP_FIELD && payload && payload[process.env.OAUTH_GROUP_FIELD]
+        ? payload[process.env.OAUTH_GROUP_FIELD]
+        : [];
+
+    const allowedGroups = 
+      process.env.OAUTH_ALLOWED_GROUPS
+        ? process.env.OAUTH_ALLOWED_GROUPS.split(',').map(group => group.toLowerCase().trim())
+        : [];
+    
+    if (
+      process.env.OAUTH_ALLOWED_GROUPS && 
+      !groups.some(group => allowedGroups.includes(group.toLowerCase().trim()))
+    ) {
+      return { error: `Username ${login} does not belong to an allowed group` };
+    }
+
     if (access_token) {
       return {
         accessToken: jwt.sign({ login }, tokenSecret, { expiresIn: getTokenLifetime() }),


### PR DESCRIPTION
Added option to have OAUTH_ALLOWED_GROUPS as comma separated value in environment config for OAUTH.

Required values in config will be:
1) OAUTH_GROUP_FIELD 
2) OAUTH_ALLOWED_GROUPS

This is similar to OAUTH_ALLOWED_LOGINS but it is for OAUTH group based.