### PR TITLE
feat: per-user permissions when using oauth, follow-up

### DIFF
--- a/packages/api/src/utility/hasPermission.js
+++ b/packages/api/src/utility/hasPermission.js
@@ -39,7 +39,7 @@ function getLogins() {
       permissions: process.env.PERMISSIONS,
     });
   }
-  if (process.env.LOGINS || process.env.OAUTH_PERMISSIONS) {
+  if (process.env.LOGINS) {
     const logins = _.compact(process.env.LOGINS.split(',').map(x => x.trim()));
     for (const login of logins) {
       const password = process.env[`LOGIN_PASSWORD_${login}`];
@@ -51,13 +51,18 @@ function getLogins() {
           permissions,
         });
       }
-      if (process.env.OAUTH_PERMISSIONS) {
-        res.push({
-          login,
-          password: null,
-          permissions,
-        })
-      }
+    }
+  }
+  else if (process.env.OAUTH_PERMISSIONS) {
+    const login_permission_keys = Object.keys(process.env).filter((key) => _.startsWith(key, 'LOGIN_PERMISSIONS_'))
+    for (const permissions_key of login_permission_keys) {
+      const login = permissions_key.replace('LOGIN_PERMISSIONS_', '');
+      const permissions = process.env[permissions_key];
+      res.push({
+        login,
+        password: null,
+        permissions,
+      })
     }
   }
 

--- a/packages/api/src/utility/hasPermission.js
+++ b/packages/api/src/utility/hasPermission.js
@@ -9,7 +9,8 @@ function hasPermission(tested, req) {
     return true;
   }
   const { user } = (req && req.auth) || {};
-  const key = user || '';
+  const { login } = (process.env.OAUTH_PERMISSIONS && req && req.user) || {};
+  const key = user || login || '';
   const logins = getLogins();
 
   if (!userPermissions[key]) {
@@ -58,11 +59,7 @@ function getLogins() {
     for (const permissions_key of login_permission_keys) {
       const login = permissions_key.replace('LOGIN_PERMISSIONS_', '');
       const permissions = process.env[permissions_key];
-      res.push({
-        login,
-        password: null,
-        permissions,
-      })
+      userPermissions[login] = compilePermissions(permissions);
     }
   }
 


### PR DESCRIPTION
# Description

This is a follow-up to https://github.com/dbgate/dbgate/pull/770

After testing, I found that the original implementation had issues that ultimately made the code change unusable. This is a change set to address those issues.

The original change created login entries with `null` passwords when the `OAUTH_PERMISSIONS` env var was enabled, but this presents two issues:
1. If the `LOGINS` env var is not declared, the app crashes
2. If the `LOGINS` env var _is_ declared, OAuth cannot be used

In this PR the implementation is changed, instead of creating users from `LOGINS`, read all entries of `LOGIN_PERMISSIONS_x`, and **directly create `userPermissions` entries**.

Second issue: `hasPermission` does not work with OAuth, because the `authMiddleware` method puts the user information in `req.user`, and not `req.auth`. To resolve this issue, I have added a narrow change to `hasPermission` that allows it to check for `req.user.login` **if and only if `OAUTH_PERMISSIONS` is enabled.**

# Testing

If you have a dbgate test environment setup, and an oauth provider you can use, this is roughly how you may setup your environment variables to test this change:

```
export OAUTH_PERMISSIONS="1" # enables the feature
export OAUTH_CLIENT_ID="your-client-id" # must be filled in per your environment
export OAUTH_CLIENT_SECRET="your-client-secret" # must be filled in per your environment
export OAUTH_AUTH="your-auth-endpoint" # must be filled in per your environment
export OAUTH_TOKEN="your-auth-token-endpoint" # must be filled in per your environment
export OAUTH_SCOPE="your-oauth-scope" # must be filled in per your environment
export OAUTH_LOGIN_FIELD="your-login-field" # must be filled in per your environment, it's probably "sub"

## Permissions
export LOGIN_PERMISSIONS_username="~*, widgets/database" # username should be replaced with the expected username
```