### PR TITLE
Fix 727: access_token not a jwt

### DIFF
--- a/packages/api/src/auth/authProvider.js
+++ b/packages/api/src/auth/authProvider.js
@@ -83,9 +83,16 @@ class OAuthProvider extends AuthProviderBase {
       )}&client_id=${process.env.OAUTH_CLIENT_ID}&client_secret=${process.env.OAUTH_CLIENT_SECRET}${scopeParam}`
     );
 
-    const { access_token, refresh_token } = resp.data;
+    const { access_token, refresh_token, id_token } = resp.data;
 
-    const payload = jwt.decode(access_token);
+    var payload = jwt.decode(access_token);
+
+    // Fallback to id_token in case the access_token is not a JWT
+    // https://www.oauth.com/oauth2-servers/access-tokens/
+    // https://github.com/dbgate/dbgate/issues/727
+    if (!payload && id_token) {
+      payload = jwt.decode(id_token);
+    }
 
     logger.info({ payload }, 'User payload returned from OAUTH');
 


### PR DESCRIPTION
Fixes #727

The response of the oauth token endpoint doesn not always contain n access_token in JWT format, in these cases a fallback to the id_token should be tried to get the payload.