### PR TITLE
Update postgres plugin drivers.js

### DIFF
--- a/plugins/dbgate-plugin-postgres/src/frontend/drivers.js
+++ b/plugins/dbgate-plugin-postgres/src/frontend/drivers.js
@@ -2,7 +2,7 @@ const { driverBase } = global.DBGATE_PACKAGES['dbgate-tools'];
 const Dumper = require('./Dumper');
 const { postgreSplitterOptions } = require('dbgate-query-splitter/lib/options');
 
-const spatialTypes = ['GEOGRAPHY'];
+const spatialTypes = ['GEOGRAPHY','GEOMETRY'];
 
 /** @type {import('dbgate-types').SqlDialect} */
 const dialect = {


### PR DESCRIPTION
Adding `geometry` to spatial types to allow the cell view to call `ST_AsText` on the underlying data, similar to its current handling of `geography`.
 
*maybe* fixes dbgate/dbgate#307
