### PR TITLE
Apply a dark theme to the startup screen if the user prefers dark mode

### DIFF
--- a/packages/web/index.html.tpl
+++ b/packages/web/index.html.tpl
@@ -30,6 +30,12 @@
     <script defer src="build/bundle.js"></script>
 
     <style>
+      @media (prefers-color-scheme: dark) {
+        .lds-ellipsis div {
+          background-color: white !important;
+        }
+      }
+
       .lds-ellipsis {
         display: inline-block;
         position: relative;

--- a/packages/web/public/global.css
+++ b/packages/web/public/global.css
@@ -11,6 +11,13 @@ body {
   overflow: hidden;
 }
 
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #151515;
+    color: white;
+  }
+}
+
 .horizontal-split-handle {
   background-color: var(--theme-border);
   width: var(--dim-splitter-thickness);


### PR DESCRIPTION
Fixes #316

In a dark themed environment, the white startup screen can be annoying.

This PR uses `@media (prefers-color-scheme: dark)` to check if the startup screen should have a dark theme, and changes the background and text colors accordingly.