### PR TITLE
feat: add support for plain-text auth for Cassandra

### DIFF
--- a/plugins/dbgate-plugin-cassandra/src/backend/driver.js
+++ b/plugins/dbgate-plugin-cassandra/src/backend/driver.js
@@ -44,9 +44,17 @@ const driver = {
   analyserClass: Analyser,
   // creating connection
   async connect({ server, user, password, database, localDataCenter, useDatabaseUrl, databaseUrl }) {
+    let credentials;
+    
+    if (user && password) {
+      credentials = {
+        username: user,
+        password,
+      }
+    } 
+
     const client = new cassandra.Client({
-      // user,
-      // password,
+      credentials,
       contactPoints: server.split(','),
       localDataCenter: localDataCenter ?? this.defaultLocalDataCenter,
       keyspace: database,


### PR DESCRIPTION
This PR adds support for Cassandra plain-text authentication  (https://github.com/datastax/nodejs-driver/tree/master/doc/features/auth). Default `NoAuth` provider is used if either `user` or `password` are missing