### PR TITLE
Add source label to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22
 
+LABEL org.opencontainers.image.source="https://github.com/dbgate/dbgate"
+
 RUN apt-get update && apt-get install -y \
     iputils-ping \
     iproute2 \

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,5 +1,7 @@
 FROM node:18-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/dbgate/dbgate"
+
 WORKDIR /home/dbgate-docker
 
 RUN apk --no-cache upgrade \


### PR DESCRIPTION
Add source label to the container. This allows services such as Renovate bot (which keeps dependencies up to date) to find the change log and include it in the PR it opens.

https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md

Here's an example of a repo that [includes the label](https://github.com/prometheus/prometheus/blob/main/Dockerfile#L5), and how it shows up in the pr (note the Release Notes).

|prometheus|dbgate|
|--|--|
|<img width="400" alt="Screenshot 2025-05-05 at 12 49 03 PM" src="https://github.com/user-attachments/assets/9101286e-3adc-4d71-b183-e9c8eeb40872" />|<img width="400" alt="Screenshot 2025-05-05 at 12 49 39 PM" src="https://github.com/user-attachments/assets/ff1bbf53-4214-4783-bd27-46ed3adf7e91" />|
