### PR TITLE
feat: redesign CommandPalette

### DIFF
--- a/packages/web/src/commands/CommandPalette.svelte
+++ b/packages/web/src/commands/CommandPalette.svelte
@@ -164,109 +164,175 @@
   }}
   data-testid='CommandPalette_main'
 >
-  <div class="pages">
-    <div
-      class="page"
-      class:selected={$visibleCommandPalette == 'menu'}
-      on:click={() => {
-        $visibleCommandPalette = 'menu';
-        domInput.focus();
-      }}
-    >
-      <FontIcon icon="icon menu" /> Commands
+  <div 
+    class="overlay" 
+    on:click={() => {
+      $visibleCommandPalette = null;
+    }}
+  />
+  <div class="palette">
+    <div class="pages">
+      <div
+        class="page"
+        class:selected={$visibleCommandPalette == 'menu'}
+        on:click={() => {
+          $visibleCommandPalette = 'menu';
+          domInput.focus();
+        }}
+      >
+        <FontIcon icon="icon menu" /> Commands
+      </div>
+      <div
+        class="page"
+        class:selected={$visibleCommandPalette == 'database'}
+        on:click={() => {
+          $visibleCommandPalette = 'database';
+          domInput.focus();
+        }}
+      >
+        <FontIcon icon="icon database" /> Database
+      </div>
     </div>
-    <div
-      class="page"
-      class:selected={$visibleCommandPalette == 'database'}
-      on:click={() => {
-        $visibleCommandPalette = 'database';
-        domInput.focus();
-      }}
-    >
-      <FontIcon icon="icon database" /> Database
-    </div>
-  </div>
-  <div class="mainInner">
-    <div class="search">
-      <input
-        type="text"
-        bind:this={domInput}
-        bind:value={filter}
-        on:keydown={handleKeyDown}
-        placeholder={parentCommand?.text ||
-          ($visibleCommandPalette == 'database' ? 'Search in database' : 'Search in commands')}
-      />
-    </div>
-    <div class="content">
-      {#each filteredItems as command, index}
-        <div
-          class="command"
-          class:selected={index == selectedIndex}
-          on:click={() => handleCommand(command)}
-          bind:this={domItems[index]}
-        >
-          <div>
-            {#if command.icon}
-              <span class="mr-1"><FontIcon icon={command.icon} /></span>
+    <div class="mainInner">
+      <div class="search">
+        <input
+          type="text"
+          bind:this={domInput}
+          bind:value={filter}
+          on:keydown={handleKeyDown}
+          placeholder={parentCommand?.text ||
+            ($visibleCommandPalette == 'database' ? 'Search in database' : 'Search in commands')}
+        />
+      </div>
+      <div class="content">
+        {#each filteredItems as command, index}
+          <div
+            class="command"
+            class:selected={index == selectedIndex}
+            on:click={() => handleCommand(command)}
+            bind:this={domItems[index]}
+          >
+            <div>
+              {#if command.icon}
+                <span class="mr-1"><FontIcon icon={command.icon} /></span>
+              {/if}
+              {@html command.text}
+            </div>
+            {#if command.keyText}
+              <div class="shortcut">{formatKeyText(command.keyText)}</div>
             {/if}
-            {@html command.text}
           </div>
-          {#if command.keyText}
-            <div class="shortcut">{formatKeyText(command.keyText)}</div>
-          {/if}
-        </div>
-      {/each}
+        {/each}
+      </div>
     </div>
   </div>
 </div>
 
 <style>
   .main {
-    width: 500px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 100px;
+  }
+
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index: 1;
+  }
+
+  .palette {
+    position: relative;
+    z-index: 2;
+    width: 600px;
     background: var(--theme-bg-2);
+    border-radius: 4px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 
   .mainInner {
-    padding: 5px;
+    padding: 8px;
   }
 
   .content {
-    max-height: 400px;
-    overflow-y: scroll;
+    max-height: 500px;
+    overflow-y: auto;
+    margin-top: 8px;
   }
+
   .search {
     display: flex;
+    margin-bottom: 8px;
   }
+
   input {
     width: 100%;
+    padding: 8px;
+    background: var(--theme-bg-1);
+    border: 1px solid var(--theme-border);
+    border-radius: 4px;
+    color: var(--theme-font);
+    font-size: 14px;
   }
+
+  input:focus {
+    outline: none;
+    border-color: var(--theme-accent);
+  }
+
   .command {
-    padding: 5px;
+    padding: 8px 12px;
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    border-radius: 4px;
   }
+
   .command:hover {
     background: var(--theme-bg-3);
   }
+
   .command.selected {
     background: var(--theme-bg-selected);
   }
+
   .shortcut {
     background: var(--theme-bg-3);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+    color: var(--theme-font-dimmed);
   }
 
   .pages {
     display: flex;
+    border-bottom: 1px solid var(--theme-border);
   }
+
   .page {
-    padding: 5px;
-    border: 1px solid var(--theme-border);
+    padding: 8px 16px;
     cursor: pointer;
+    color: var(--theme-font-dimmed);
+    border-bottom: 2px solid transparent;
   }
+
   .page:hover {
-    color: var(--theme-font-hover);
+    color: var(--theme-font);
   }
+
   .page.selected {
-    background: var(--theme-bg-1);
+    color: var(--theme-font);
+    border-bottom-color: var(--theme-accent);
   }
 </style>


### PR DESCRIPTION
This pull request enhances the `CommandPalette` component by improving its UI/UX design. The changes include the addition of a modal overlay, updates to the layout and styling. The primary goal is for the new palette to draw attention more than the old left-sided palette which had several UX issues on ultrawide displays.

### UI/UX Improvements:

* Added a modal overlay (`.overlay`) to dim the background when the Command Palette is active. Clicking the overlay closes the Command Palette.
* Updated the `.main` container to use a fixed position and center the Command Palette on the screen with padding for better visibility.
* Improved the `.palette` styling with a rounded border, shadow effect, and increased width for a more modern look similarly to VSCode's palette.
* Adjusted `.page` styles to use a color and border-based indication for selected states, replacing the previous background-based approach.
* Improved input and command styles, including padding, borders, and hover/focus states.

See https://github.com/dbgate/dbgate/discussions/1097 for screenshots. This implementation is the last one which centers and top aligns the modal.