### PR TITLE
feat: Option to toggle database formats

### DIFF
--- a/packages/web/src/settings/ConnectionDriverFields.svelte
+++ b/packages/web/src/settings/ConnectionDriverFields.svelte
@@ -10,7 +10,7 @@
   import FormSelectField from '../forms/FormSelectField.svelte';
 
   import FormTextField from '../forms/FormTextField.svelte';
-  import { extensions, getCurrentConfig, openedConnections, openedSingleDatabaseConnections } from '../stores';
+  import { extensions, getCurrentConfig, openedConnections, openedSingleDatabaseConnections, toggledDatabases } from '../stores';
   import getElectron from '../utility/getElectron';
   import { useAuthTypes, useConfig } from '../utility/metadataLoaders';
   import FormColorField from '../forms/FormColorField.svelte';
@@ -98,7 +98,8 @@
     ..._.sortBy(
       $extensions.drivers
         // .filter(driver => !driver.isElectronOnly || electron)
-        .map(driver => ({
+        .filter((driver => $toggledDatabases.get(driver.title)))
+        .map((driver) => ({
           value: driver.engine,
           label: driver.title,
         })),

--- a/packages/web/src/settings/ConnectionSettings.svelte
+++ b/packages/web/src/settings/ConnectionSettings.svelte
@@ -5,7 +5,7 @@
   import FormSelectField from '../forms/FormSelectField.svelte';
   import FormTextField from '../forms/FormTextField.svelte';
   import FormValues from '../forms/FormValues.svelte';
-  import { lockedDatabaseMode } from '../stores';
+  import { lockedDatabaseMode, extensions } from '../stores';
   import { _t } from '../translations';
 </script>
 
@@ -56,6 +56,17 @@
       defaultValue="15"
       disabled={values['session.autoClose'] === false}
     />
+
+    <div class="heading">{_t('settings.connectionSuggestions', { defaultMessage: 'Connection suggestions' })}</div>
+    {#each $extensions.drivers as driver, index}
+      <FormCheckboxField
+        name="settings.connectionSuggestions.{driver.title}"
+        label={_t('settings.connectionSuggestions.' + driver.title, {
+          defaultMessage: driver.title,
+        })}
+        defaultValue={true}
+      />
+    {/each}
   </FormValues>
 </div>
 

--- a/packages/web/src/stores.ts
+++ b/packages/web/src/stores.ts
@@ -473,3 +473,15 @@ cloudSigninTokenHolder.subscribe(value => {
 });
 export const getCloudSigninTokenHolder = () => cloudSigninTokenHolderValue;
 
+export const toggledDatabases = derived([extensions, useSettings()], ([$extensions, $settings]) => {
+  const res = new Map<string, boolean>();
+
+  if (!$extensions || !$settings)
+    return res;
+
+  for (const driver of $extensions.drivers) {
+    res.set(driver.title, !!$settings[`settings.connectionSuggestions.${driver.title}`]);
+  }
+  
+  return res;
+});


### PR DESCRIPTION
- Added section to Settings->Connection: "Connection Suggestion" where users can enable/disable certain database formats.
- Create new connection drop down now only shows enabled formats.
- Unable to disable SQLite and DuckDB options from showing up in File menu.

Related Issue: #1295 