### PR TITLE
fix(clickhouse): show query results for CTE (WITH) queries

### DIFF
--- a/plugins/dbgate-plugin-clickhouse/src/backend/driver.js
+++ b/plugins/dbgate-plugin-clickhouse/src/backend/driver.js
@@ -61,7 +61,7 @@ const driver = {
   // called in query console
   async stream(dbhan, query, options) {
     try {
-      if (!query.match(/^\s*SELECT/i)) {
+      if (!query.match(/^\s*(SELECT|WITH)\b/i)) {
         const resp = await dbhan.client.command({
           query,
         });


### PR DESCRIPTION
## Problem

When executing queries with Common Table Expressions (CTEs) in the ClickHouse query console, DbGate shows "Query execution finished" but displays no data grid.

Example query that fails to show results:
```sql
WITH totals AS (
    SELECT city, count(*) AS cnt
    FROM my_table
    GROUP BY city
)
SELECT * FROM totals ORDER BY cnt DESC LIMIT 10
```

## Root cause

The `stream()` method in `plugins/dbgate-plugin-clickhouse/src/backend/driver.js` uses a regex to determine whether a query returns data:

```js
if (!query.match(/^\s*SELECT/i)) {
```

This only matches queries starting with `SELECT`. CTE queries start with `WITH`, so they fall into the non-SELECT branch and are sent through `client.command()` — which is designed for DDL/DML operations that don't return result sets. The results are silently discarded.

## Fix

Update the regex to also match queries starting with `WITH`:

```js
if (!query.match(/^\s*(SELECT|WITH)\b/i)) {
```

This routes CTE queries through `client.query()` with the `JSONCompactEachRowWithNamesAndTypes` format, which correctly parses and displays column names, types, and rows in the data grid.

The `\b` word boundary ensures we don't accidentally match identifiers that happen to start with these keywords.

## Testing

- CTE queries (`WITH ... SELECT`) now display results in the data grid
- Regular `SELECT` queries continue to work as before
- Non-SELECT queries (`INSERT`, `CREATE`, `ALTER`, etc.) continue to use `client.command()`

Fixes #1138