### PR TITLE
fix: support mongodb+srv:// connection URLs with SSH tunnels

### DIFF
--- a/packages/api/src/controllers/databaseConnections.js
+++ b/packages/api/src/controllers/databaseConnections.js
@@ -947,13 +947,20 @@ module.exports = {
     }
 
     if (connection.useSshTunnel) {
-      const tunnel = await getSshTunnel(connection);
+      const tunnelMode = driver.getSSHTunnelMode ? driver.getSSHTunnelMode(connection) : 'forward';
+
+      const tunnel = await getSshTunnel(connection, tunnelMode === 'socks' ? { mode: 'socks' } : undefined);
       if (tunnel.state == 'error') {
         throw new Error(tunnel.message);
       }
 
-      connection.server = tunnel.localHost;
-      connection.port = tunnel.localPort;
+      if (tunnelMode === 'socks') {
+        connection.sshSocksProxyHost = tunnel.localHost;
+        connection.sshSocksProxyPort = tunnel.localPort;
+      } else {
+        connection.server = tunnel.localHost;
+        connection.port = tunnel.localPort;
+      }
     }
 
     const settingsValue = await config.getSettings();

--- a/packages/api/src/proc/sshForwardProcess.js
+++ b/packages/api/src/proc/sshForwardProcess.js
@@ -30,10 +30,14 @@ async function getSshConnection(connection, tunnelConfig) {
   return sshConn;
 }
 
-async function handleStart({ connection, tunnelConfig }) {
+async function handleStart({ connection, tunnelConfig, mode }) {
   try {
     const sshConn = await getSshConnection(connection, tunnelConfig);
-    await sshConn.forward(tunnelConfig);
+    if (mode === 'socks') {
+      await sshConn.socksForward(tunnelConfig);
+    } else {
+      await sshConn.forward(tunnelConfig);
+    }
 
     process.send({
       msgtype: 'connected',

--- a/packages/api/src/utility/SSHConnection.js
+++ b/packages/api/src/utility/SSHConnection.js
@@ -254,6 +254,7 @@ class SSHConnection {
         .createServer(socket => {
           this._handleSocks5(socket, connection, options);
         })
+        .on('error', reject)
         .listen(options.fromPort, this.options.bindHost, () => {
           return resolve();
         });
@@ -265,6 +266,13 @@ class SSHConnection {
 
     socket.once('data', greeting => {
       if (!greeting || greeting.length < 2 || greeting[0] !== 0x05) {
+        socket.destroy();
+        return;
+      }
+      const nmethods = greeting[1];
+      const methods = greeting.slice(2, 2 + nmethods);
+      if (!methods.includes(0x00)) {
+        socket.write(Buffer.from([0x05, 0xff]));
         socket.destroy();
         return;
       }

--- a/packages/api/src/utility/SSHConnection.js
+++ b/packages/api/src/utility/SSHConnection.js
@@ -246,6 +246,82 @@ class SSHConnection {
         });
     });
   }
+
+  async socksForward(options) {
+    const connection = await this.establish();
+    return new Promise((resolve, reject) => {
+      this.server = net
+        .createServer(socket => {
+          this._handleSocks5(socket, connection, options);
+        })
+        .listen(options.fromPort, this.options.bindHost, () => {
+          return resolve();
+        });
+    });
+  }
+
+  _handleSocks5(socket, sshConnection, options) {
+    socket.once('error', () => socket.destroy());
+
+    socket.once('data', greeting => {
+      if (!greeting || greeting.length < 2 || greeting[0] !== 0x05) {
+        socket.destroy();
+        return;
+      }
+      socket.write(Buffer.from([0x05, 0x00]));
+
+      socket.once('data', request => {
+        if (request.length < 4 || request[0] !== 0x05 || request[1] !== 0x01) {
+          socket.write(Buffer.from([0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          socket.destroy();
+          return;
+        }
+
+        let host;
+        let port;
+        const addrType = request[3];
+
+        if (addrType === 0x01) {
+          if (request.length < 10) { socket.destroy(); return; }
+          host = `${request[4]}.${request[5]}.${request[6]}.${request[7]}`;
+          port = request.readUInt16BE(8);
+        } else if (addrType === 0x03) {
+          const domainLen = request[4];
+          if (request.length < 5 + domainLen + 2) { socket.destroy(); return; }
+          host = request.slice(5, 5 + domainLen).toString();
+          port = request.readUInt16BE(5 + domainLen);
+        } else if (addrType === 0x04) {
+          if (request.length < 22) { socket.destroy(); return; }
+          const ipv6Parts = [];
+          for (let i = 0; i < 8; i++) {
+            ipv6Parts.push(request.readUInt16BE(4 + i * 2).toString(16));
+          }
+          host = ipv6Parts.join(':');
+          port = request.readUInt16BE(20);
+        } else {
+          socket.write(Buffer.from([0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          socket.destroy();
+          return;
+        }
+
+        this.debug('SOCKS5 CONNECT to "%s:%d"', host, port);
+
+        sshConnection.forwardOut(this.options.bindHost, options.fromPort, host, port, (error, stream) => {
+          if (error) {
+            socket.write(Buffer.from([0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+            socket.destroy();
+            return;
+          }
+          socket.write(Buffer.from([0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          socket.pipe(stream);
+          stream.pipe(socket);
+
+          stream.on('error', () => socket.destroy());
+          socket.on('error', () => stream.destroy());
+        });
+      });
+    });
+  }
 }
 
 module.exports = { SSHConnection };

--- a/packages/api/src/utility/connectUtility.js
+++ b/packages/api/src/utility/connectUtility.js
@@ -122,13 +122,20 @@ async function connectUtility(driver, storedConnection, connectionMode, addition
   }
 
   if (connection.useSshTunnel) {
-    const tunnel = await getSshTunnelProxy(connection);
+    const tunnelMode = driver.getSSHTunnelMode ? driver.getSSHTunnelMode(connection) : 'forward';
+
+    const tunnel = await getSshTunnelProxy(connection, tunnelMode === 'socks' ? { mode: 'socks' } : undefined);
     if (tunnel.state == 'error') {
       throw new Error(tunnel.message);
     }
 
-    connection.server = tunnel.localHost;
-    connection.port = tunnel.localPort;
+    if (tunnelMode === 'socks') {
+      connection.sshSocksProxyHost = tunnel.localHost;
+      connection.sshSocksProxyPort = tunnel.localPort;
+    } else {
+      connection.server = tunnel.localHost;
+      connection.port = tunnel.localPort;
+    }
   }
 
   connection.ssl = await extractConnectionSslParams(connection);

--- a/packages/api/src/utility/sshTunnel.js
+++ b/packages/api/src/utility/sshTunnel.js
@@ -23,7 +23,7 @@ const CONNECTION_FIELDS = [
 ];
 const TUNNEL_FIELDS = [...CONNECTION_FIELDS, 'server', 'port'];
 
-function callForwardProcess(connection, tunnelConfig, tunnelCacheKey) {
+function callForwardProcess(connection, tunnelConfig, tunnelCacheKey, mode) {
   let subprocess = fork(
     global['API_PACKAGE'] || process.argv[1],
     ['--is-forked-api', '--start-process', 'sshForwardProcess', ...processArgs.getPassArgs()],
@@ -38,6 +38,7 @@ function callForwardProcess(connection, tunnelConfig, tunnelCacheKey) {
       msgtype: 'connect',
       connection,
       tunnelConfig,
+      mode,
     });
   } catch (err) {
     logger.error(extractErrorLogData(err), 'DBGM-00174 Error connecting SSH');
@@ -77,10 +78,11 @@ function callForwardProcess(connection, tunnelConfig, tunnelCacheKey) {
   });
 }
 
-async function getSshTunnel(connection) {
+async function getSshTunnel(connection, options) {
+  const mode = options?.mode || 'forward';
   const config = require('../controllers/config');
 
-  const tunnelCacheKey = stableStringify(_.pick(connection, TUNNEL_FIELDS));
+  const tunnelCacheKey = stableStringify({ ..._.pick(connection, TUNNEL_FIELDS), mode });
   const globalSettings = await config.getSettings();
 
   return await lock.acquire(tunnelCacheKey, async () => {
@@ -92,19 +94,31 @@ async function getSshTunnel(connection) {
     const tunnelConfig = {
       fromPort: localPort,
       fromHost: localHost,
-      toPort: connection.port,
-      toHost: connection.server,
+      toPort: mode === 'socks' ? undefined : connection.port,
+      toHost: mode === 'socks' ? undefined : connection.server,
     };
     try {
-      logger.info(
-        `DBGM-00093 Creating SSH tunnel to ${connection.sshHost}-${connection.server}:${connection.port}, using local port ${localPort}`
-      );
+      if (mode === 'socks') {
+        logger.info(
+          `DBGM-00093 Creating SSH SOCKS proxy via ${connection.sshHost}, using local port ${localPort}`
+        );
+      } else {
+        logger.info(
+          `DBGM-00093 Creating SSH tunnel to ${connection.sshHost}-${connection.server}:${connection.port}, using local port ${localPort}`
+        );
+      }
 
-      const subprocess = await callForwardProcess(connection, tunnelConfig, tunnelCacheKey);
+      const subprocess = await callForwardProcess(connection, tunnelConfig, tunnelCacheKey, mode);
 
-      logger.info(
-        `DBGM-00094 Created SSH tunnel to ${connection.sshHost}-${connection.server}:${connection.port}, using local port ${localPort}`
-      );
+      if (mode === 'socks') {
+        logger.info(
+          `DBGM-00094 Created SSH SOCKS proxy via ${connection.sshHost}, using local port ${localPort}`
+        );
+      } else {
+        logger.info(
+          `DBGM-00094 Created SSH tunnel to ${connection.sshHost}-${connection.server}:${connection.port}, using local port ${localPort}`
+        );
+      }
 
       sshTunnelCache[tunnelCacheKey] = {
         state: 'ok',

--- a/packages/api/src/utility/sshTunnelProxy.js
+++ b/packages/api/src/utility/sshTunnelProxy.js
@@ -5,8 +5,8 @@ const logger = getLogger('sshTunnelProxy');
 
 const dispatchedMessages = {};
 
-async function handleGetSshTunnelRequest({ msgid, connection }, subprocess) {
-  const response = await getSshTunnel(connection);
+async function handleGetSshTunnelRequest({ msgid, connection, options }, subprocess) {
+  const response = await getSshTunnel(connection, options);
   try {
     subprocess.send({ msgtype: 'getsshtunnel-response', msgid, response });
   } catch (err) {
@@ -20,10 +20,10 @@ function handleGetSshTunnelResponse({ msgid, response }, subprocess) {
   resolve(response);
 }
 
-async function getSshTunnelProxy(connection) {
-  if (!process.send) return getSshTunnel(connection);
+async function getSshTunnelProxy(connection, options) {
+  if (!process.send) return getSshTunnel(connection, options);
   const msgid = crypto.randomUUID();
-  process.send({ msgtype: 'getsshtunnel-request', msgid, connection });
+  process.send({ msgtype: 'getsshtunnel-request', msgid, connection, options });
   return new Promise((resolve, reject) => {
     dispatchedMessages[msgid] = { resolve, reject };
   });

--- a/plugins/dbgate-plugin-mongo/src/backend/drivers.js
+++ b/plugins/dbgate-plugin-mongo/src/backend/drivers.js
@@ -102,16 +102,39 @@ async function getScriptableDb(dbhan) {
 const drivers = driverBases.map((driverBase) => ({
   ...driverBase,
   analyserClass: Analyser,
-  async connect({ server, port, user, password, database, useDatabaseUrl, databaseUrl, ssl, useSshTunnel }) {
+  getSSHTunnelMode(connection) {
+    if (connection.useDatabaseUrl && connection.databaseUrl && connection.databaseUrl.startsWith('mongodb+srv://')) {
+      return 'socks';
+    }
+    return 'forward';
+  },
+  async connect({
+    server,
+    port,
+    user,
+    password,
+    database,
+    useDatabaseUrl,
+    databaseUrl,
+    ssl,
+    useSshTunnel,
+    sshSocksProxyHost,
+    sshSocksProxyPort,
+  }) {
     let mongoUrl;
 
     if (useDatabaseUrl) {
-      if (useSshTunnel) {
-        // change port to ssh tunnel port
+      if (useSshTunnel && !sshSocksProxyHost) {
+        if (databaseUrl.startsWith('mongodb+srv://')) {
+          throw new Error('mongodb+srv:// URLs require SOCKS proxy mode for SSH tunneling');
+        }
+        // change port to ssh tunnel port (standard mongodb:// URLs)
         const url = new URL(databaseUrl);
         url.port = port;
         mongoUrl = url.href;
       } else {
+        // For mongodb+srv:// with SSH, the SOCKS proxy handles routing
+        // so we keep the original URL intact
         mongoUrl = databaseUrl;
       }
     } else {
@@ -123,6 +146,12 @@ const drivers = driverBases.map((driverBase) => ({
     const options = {
       // useUnifiedTopology: true, // this options has no longer effect
     };
+
+    if (sshSocksProxyHost) {
+      options.proxyHost = sshSocksProxyHost;
+      options.proxyPort = sshSocksProxyPort;
+    }
+
     if (ssl) {
       options.tls = true;
       options.tlsCAFile = ssl.sslCaFile;

--- a/plugins/dbgate-plugin-mongo/src/backend/drivers.js
+++ b/plugins/dbgate-plugin-mongo/src/backend/drivers.js
@@ -102,11 +102,8 @@ async function getScriptableDb(dbhan) {
 const drivers = driverBases.map((driverBase) => ({
   ...driverBase,
   analyserClass: Analyser,
-  getSSHTunnelMode(connection) {
-    if (connection.useDatabaseUrl && connection.databaseUrl && connection.databaseUrl.startsWith('mongodb+srv://')) {
-      return 'socks';
-    }
-    return 'forward';
+  getSSHTunnelMode() {
+    return 'socks';
   },
   async connect({
     server,
@@ -117,26 +114,13 @@ const drivers = driverBases.map((driverBase) => ({
     useDatabaseUrl,
     databaseUrl,
     ssl,
-    useSshTunnel,
     sshSocksProxyHost,
     sshSocksProxyPort,
   }) {
     let mongoUrl;
 
     if (useDatabaseUrl) {
-      if (useSshTunnel && !sshSocksProxyHost) {
-        if (databaseUrl.startsWith('mongodb+srv://')) {
-          throw new Error('mongodb+srv:// URLs require SOCKS proxy mode for SSH tunneling');
-        }
-        // change port to ssh tunnel port (standard mongodb:// URLs)
-        const url = new URL(databaseUrl);
-        url.port = port;
-        mongoUrl = url.href;
-      } else {
-        // For mongodb+srv:// with SSH, the SOCKS proxy handles routing
-        // so we keep the original URL intact
-        mongoUrl = databaseUrl;
-      }
+      mongoUrl = databaseUrl;
     } else {
       mongoUrl = user
         ? `mongodb://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${server}:${port}`


### PR DESCRIPTION
## Summary
  - `mongodb+srv://` connection URLs crashed with `MongoParseError: mongodb+srv URI cannot have port number` when used with SSH tunnels
  - The existing SSH tunnel creates a local port forward and rewrites the URL with a port, but SRV URLs cannot have ports since they use DNS SRV records to discover replica set members
  - Added a SOCKS5 proxy mode to the SSH tunnel infrastructure so the MongoDB driver can route all connections (including DNS-discovered shards) through the tunnel without modifying the URL
  - Regular `mongodb://` connections with SSH tunnels are unchanged

  ## How it works
  - Drivers can implement `getSSHTunnelMode(connection)` returning `'socks'` or `'forward'`
  - The mongo driver returns `'socks'` for `mongodb+srv://` URLs
  - In SOCKS mode, a local SOCKS5 server routes each connection through SSH's `forwardOut`
  - The MongoDB driver's built-in SOCKS5 support (`proxyHost`/`proxyPort`) handles the rest. DNS SRV resolution and connections to all replica set members go through the proxy transparently

Closes: #1343 