### PR TITLE
Upgrade node-cron to v4

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "ncp": "^2.0.0",
-    "node-cron": "^2.0.3",
+    "node-cron": "^4.5.0",
     "on-finished": "^2.4.1",
     "pinomin": "^1.0.5",
     "portfinder": "^1.0.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11496,13 +11496,10 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-cron@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-2.0.3.tgz#b9649784d0d6c00758410eef22fa54a10e3f602d"
-  integrity sha512-eJI+QitXlwcgiZwNNSRbqsjeZMp5shyajMR81RZCqeW0ZDEj4zU9tpd4nTh/1JsBiKbF8d08FCewiipDmVIYjg==
-  dependencies:
-    opencollective-postinstall "^2.0.0"
-    tz-offset "0.0.1"
+node-cron@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-4.5.0.tgz#284908d302415a32e0774b3a8c8184d423e262a8"
+  integrity sha512-4Trh+kjvbXokyJkwQumvD5YAgeJfgHLR/sKyu71uSmxfCR5QMO1hldpvmFZOICN5pLgNY+J5Y8+ar3XKo5/4tQ==
 
 node-domexception@^1.0.0:
   version "1.0.0"
@@ -11915,11 +11912,6 @@ openapi-types@^12.1.3:
   version "12.1.3"
   resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.1.3.tgz#471995eb26c4b97b7bd356aacf7b91b73e777dd3"
   integrity sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==
-
-opencollective-postinstall@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 openid-client@^5.6.4:
   version "5.7.1"
@@ -14768,11 +14760,6 @@ typical@^7.1.1, typical@^7.2.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-7.3.0.tgz#930376be344228709f134613911fa22aa09617a4"
   integrity sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==
-
-tz-offset@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/tz-offset/-/tz-offset-0.0.1.tgz#fef920257024d3583ed9072a767721a18bdb8a76"
-  integrity sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Bumps `node-cron` from `^2.0.3` to `^4.5.0` in `dbgate-api`.

Context: I maintain node-cron, and v2 is on its way out, so it's a good time to move.

## Why

node-cron v2 is several major versions behind. v4 is a TypeScript rewrite
with a maintained, actively supported codebase.

## Changes

- `packages/api/package.json`: `node-cron` `^2.0.3` -> `^4.5.0`
- `yarn.lock`: updated entry, plus removal of the now-unused transitive deps
  `opencollective-postinstall` and `tz-offset` (pulled only by node-cron v2)

No source changes were needed. The scheduler controller
(`packages/api/src/controllers/scheduler.js`) uses only three node-cron APIs,
all unchanged in v4:

- `cron.validate(pattern)`
- `cron.schedule(pattern, fn)`
- `task.destroy()`