### PR TITLE
Add SQL Server 2022 and 2025 version detection to MSSQL driver

### DIFF
--- a/plugins/dbgate-plugin-mssql/src/backend/driver.js
+++ b/plugins/dbgate-plugin-mssql/src/backend/driver.js
@@ -52,7 +52,9 @@ SELECT
   WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '12%' THEN 'SQL Server 2014'
   WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '13%' THEN 'SQL Server 2016'     
   WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '14%' THEN 'SQL Server 2017' 
-  WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '15%' THEN 'SQL Server 2019' 
+  WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '15%' THEN 'SQL Server 2019'
+  WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '16%' THEN 'SQL Server 2022'
+  WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) like '17%' THEN 'SQL Server 2025'
   ELSE 'Unknown'
   END AS versionText
 `;


### PR DESCRIPTION
Adds version detection for:
- SQL Server 2022 (productversion 16.x)
- SQL Server 2025 (productversion 17.x)