### PR TITLE
Fix MongoDB export dropping trailing rows under the batch size

### DIFF
--- a/plugins/dbgate-plugin-mongo/src/backend/drivers.js
+++ b/plugins/dbgate-plugin-mongo/src/backend/drivers.js
@@ -453,7 +453,7 @@ const drivers = driverBases.map((driverBase) => ({
 
     // Called once the cursor is fully read
     cursorStream.on('end', () => {
-      pass.emit('end');
+      pass.end();
     });
 
     // exprValue


### PR DESCRIPTION
MongoDB's `readQuery()` closed the output stream with `pass.emit('end')`
instead of `pass.end()`. Emitting `'end'` directly skips waiting for the
internal `PassThrough` buffer (highWaterMark: 100) to drain, so whenever
the final cursor batch was smaller than the driver's internal batch size
(~100 docs), it could still be sitting unread in the buffer when `'end'`
fired and got silently dropped from the export.

Mid-stream batches were unaffected because the async I/O between `getMore`
calls gave the consumer time to drain the buffer before the next batch
arrived — only the last, sub-100 remainder was lost.

- Replace `pass.emit('end')` with `pass.end()` in
  `plugins/dbgate-plugin-mongo/src/backend/drivers.js`
- Fixes silent data loss when exporting/querying a MongoDB collection whose
  result count isn't an exact multiple of the cursor's batch size

**To reproduce (before fix):** query or export a collection with a result
count that leaves a small remainder after ~100-row batches (e.g. 130 docs)
— the trailing rows are missing from the output.