### PR TITLE
Fix saving PostgreSQL array columns from the data grid

### DIFF
--- a/plugins/dbgate-plugin-postgres/src/frontend/Dumper.js
+++ b/plugins/dbgate-plugin-postgres/src/frontend/Dumper.js
@@ -97,10 +97,53 @@ class Dumper extends SqlDumper {
     }
   }
 
-  putValue(value) {
+  putValue(value, dataType) {
     if (value === true) this.putRaw('true');
     else if (value === false) this.putRaw('false');
-    else super.putValue(value);
+    else if (dataType && dataType.endsWith('[]') && this.tryPutArrayValue(value)) {
+      // handled as PostgreSQL array literal
+    } else super.putValue(value, dataType);
+  }
+
+  // Array columns are rendered to the user as JS/JSON arrays, so an edited cell can arrive either as a
+  // real array or as the text the user saw and retyped. Both must produce a PostgreSQL array literal.
+  // Anything else (e.g. native '{1,2}' syntax) falls through to normal string handling.
+  tryPutArrayValue(value) {
+    if (Array.isArray(value)) {
+      this.putArrayValue(value);
+      return true;
+    }
+    if (typeof value === 'string' && value.trim().startsWith('[')) {
+      let parsed;
+      try {
+        parsed = JSON.parse(value);
+      } catch (err) {
+        return false;
+      }
+      if (Array.isArray(parsed)) {
+        this.putArrayValue(parsed);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  putArrayValue(value) {
+    this.putStringValue(this.formatArrayLiteral(value));
+  }
+
+  formatArrayLiteral(value, depth = 0) {
+    // PostgreSQL arrays support at most 6 dimensions; bail out rather than recursing unbounded on malformed input
+    if (depth > 6) {
+      throw new Error('PostgreSQL arrays support at most 6 dimensions');
+    }
+    const formatElement = el => {
+      if (el === null || el === undefined) return 'NULL';
+      if (Array.isArray(el)) return this.formatArrayLiteral(el, depth + 1);
+      const str = typeof el === 'string' ? el : JSON.stringify(el);
+      return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    };
+    return `{${value.map(formatElement).join(',')}}`;
   }
 
   putByteArrayValue(value) {


### PR DESCRIPTION
## Repro

```sql
CREATE TABLE array_demo (
  id serial PRIMARY KEY,
  tags   text[],
  scores integer[],
  matrix integer[][],
  meta   jsonb
);
```

Open the table in the data grid, edit the `tags` cell, hit save:

```
ERROR: malformed array literal: "["a","b"]"
DETAIL: "[" must introduce explicitly-specified array dimensions.
```

The row cannot be saved. Same for every array-typed column.

## Generated SQL

| column | type | before | after |
|---|---|---|---|
| `tags` | `text[]` | `'["a","b"]'` ❌ | `'{"a","b"}'` |
| `scores` | `integer[]` | `'[10,20,30]'` ❌ | `'{"10","20","30"}'` |
| `matrix` | `integer[][]` | `'[[9,8],[7,6]]'` ❌ | `'{{"9","8"},{"7","6"}}'` |
| `meta` | `jsonb` | `'{"a":1}'` | `'{"a":1}'` unchanged |

Full statement, before:

```sql
UPDATE "public"."array_demo"
SET "tags"='["edited-A","edited''B"]', "matrix"='[[9,8],[7,6]]'
WHERE "id" = 1;                                    -- rejected by PostgreSQL
```

after:

```sql
UPDATE "public"."array_demo"
SET "tags"='{"edited-A","edited''B"}', "matrix"='{{"9","8"},{"7","6"}}'
WHERE "id" = 1;                                    -- OK
```

## Cause

`Dumper.putValue()` accepted only `(value)` and never passed `dataType` to
the base `SqlDumper`, so array values always fell into the generic
`JSON.stringify()` branch. PostgreSQL requires `{...}`, not `[...]`.

There is a second half. Array values reach the client as real arrays and
are rendered as JSON, so the user edits what they see and it comes back as
a **string**:

```js
putValue([9, 6],    'integer[]')  // real array   — from API / import
putValue('[ 9,6 ]', 'integer[]')  // string       — from the grid editor
```

Handling only the first fixes the API path and leaves the actual
grid-editing path broken, so both shapes are accepted.

## Changes

- Pass `dataType` through to `putValue`; dump array-typed columns as
  `{...}`, escaping each element per PostgreSQL array syntax
- Recurse into nested arrays for multi-dimensional columns
- Bound recursion at 6 levels (PostgreSQL's `MAXDIM`) so deeply nested
  input fails with an error rather than a stack overflow
- Accept a string that parses as a JSON array, so the displayed value
  round-trips

## Not affected

```js
putValue('{1,2}', 'integer[]')  // → '{1,2}'   native syntax, unchanged
putValue([1, 2],  'jsonb')      // → '[1,2]'   correct for jsonb
putValue([1, 2],  null)         // → '[1,2]'   unknown type, unchanged
```

## Import / copy path is affected too

`putValue` is also used by `createBulkInsertStreamBase`, so copying a
table with array columns failed there as well. Verified with a
postgres-to-postgres copy through `tableReader` / `copyStream` /
`tableWriter` before and after the change — after the fix every row copies
and an `EXCEPT` diff of all columns against the source returns no
differences.

## Verification

PostgreSQL 16, round-tripped through the grid save path and read back:

| case | value |
|---|---|
| quoting | `["O'Brien", "say \"hi\"", "back\\slash", "a,b"]` |
| types | `text[]` `integer[]` `numeric[]` `boolean[]` `uuid[]` `date[]` |
| edge | `[]`, `[null]`, `[""]`, `["  pad  "]`, `["한글","🎯"]` |
| dims | 2-dim, 3-dim, 4-dim |

All returned identical to input.
