### PR TITLE
Fix SSRF and local file read in download-text and download-jsl-data

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,6 +46,7 @@
     "fs-reverse": "^0.0.3",
     "get-port": "^5.1.1",
     "http": "^0.0.0",
+    "ipaddr.js": "^1.9.1",
     "is-electron": "^2.2.1",
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.0.1",

--- a/packages/api/src/controllers/files.js
+++ b/packages/api/src/controllers/files.js
@@ -335,7 +335,7 @@ module.exports = {
   downloadText_meta: true,
   async downloadText({ uri }, req) {
     if (!uri) return null;
-    const filePath = await dbgateApi.download(uri);
+    const filePath = await dbgateApi.download(uri, { safeRemoteFetch: true });
     const text = await fs.readFile(filePath, {
       encoding: 'utf-8',
     });

--- a/packages/api/src/controllers/jsldata.js
+++ b/packages/api/src/controllers/jsldata.js
@@ -373,7 +373,7 @@ module.exports = {
   downloadJslData_meta: true,
   async downloadJslData({ uri }) {
     const jslid = crypto.randomUUID();
-    await dbgateApi.download(uri, { targetFile: getJslFileName(jslid) });
+    await dbgateApi.download(uri, { targetFile: getJslFileName(jslid), safeRemoteFetch: true });
     return { jslid };
   },
 

--- a/packages/api/src/shell/download.js
+++ b/packages/api/src/shell/download.js
@@ -27,7 +27,7 @@ async function download(url, options = {}) {
       // In safeRemoteFetch mode only managed archive references are accepted.
       // Extracting from an arbitrary local zip path would be a local file read.
       if (safeRemoteFetch && !isArchiveReference) {
-        throw new Error('DBGM-00339 Only http://, https:// and archive references are allowed');
+        throw new Error('DBGM-00000 Only http://, https:// and archive references are allowed');
       }
       const destFile = targetFile || path.join(uploadsdir(), crypto.randomUUID());
       let zipFile = zipMatch[1];

--- a/packages/api/src/shell/download.js
+++ b/packages/api/src/shell/download.js
@@ -4,25 +4,49 @@ const { uploadsdir, archivedir } = require('../utility/directories');
 const { downloadFile } = require('../utility/downloader');
 const extractSingleFileFromZip = require('../utility/extractSingleFileFromZip');
 
+// In safeRemoteFetch mode the archive folder reference (the part after
+// "archive:") must stay inside the managed archive directory.
+function isSafeArchiveReference(archiveRelative) {
+  if (path.isAbsolute(archiveRelative)) {
+    return false;
+  }
+  return archiveRelative.split(/[\\/]/).every(segment => segment !== '..');
+}
+
 async function download(url, options = {}) {
-  const { targetFile } = options || {};
+  const { targetFile, safeRemoteFetch } = options || {};
   if (url) {
     if (url.match(/(^http:\/\/)|(^https:\/\/)/)) {
       const destFile = targetFile || path.join(uploadsdir(), crypto.randomUUID());
-      await downloadFile(url, destFile);
+      await downloadFile(url, destFile, { safeRemoteFetch: !!safeRemoteFetch });
       return destFile;
     }
     const zipMatch = url.match(/^zip\:\/\/(.*)\/\/(.*)$/);
     if (zipMatch) {
+      const isArchiveReference = zipMatch[1].startsWith('archive:');
+      // In safeRemoteFetch mode only managed archive references are accepted.
+      // Extracting from an arbitrary local zip path would be a local file read.
+      if (safeRemoteFetch && !isArchiveReference) {
+        throw new Error('DBGM-00339 Only http://, https:// and archive references are allowed');
+      }
       const destFile = targetFile || path.join(uploadsdir(), crypto.randomUUID());
       let zipFile = zipMatch[1];
-      if (zipFile.startsWith('archive:')) {
-        zipFile = path.join(archivedir(), zipFile.substring('archive:'.length));
+      if (isArchiveReference) {
+        const archiveRelative = zipFile.substring('archive:'.length);
+        if (safeRemoteFetch && !isSafeArchiveReference(archiveRelative)) {
+          throw new Error('DBGM-00339 Invalid archive reference');
+        }
+        zipFile = path.join(archivedir(), archiveRelative);
       }
 
       await extractSingleFileFromZip(zipFile, zipMatch[2], destFile);
       return destFile;
     }
+  }
+
+  // In safeRemoteFetch mode a bare path must not be turned into a local file read.
+  if (safeRemoteFetch) {
+    throw new Error('DBGM-00339 Only http://, https:// and archive references are allowed');
   }
 
   return url;

--- a/packages/api/src/utility/downloader.js
+++ b/packages/api/src/utility/downloader.js
@@ -18,7 +18,7 @@ function saveStreamToFile(pipedStream, fileName, maxBytes = 0) {
       pipedStream.on('data', chunk => {
         written += chunk.length;
         if (written > maxBytes) {
-          pipedStream.destroy(new Error('DBGM-00338 Downloaded file exceeds the maximum allowed size'));
+          pipedStream.destroy(new Error('DBGM-00000 Downloaded file exceeds the maximum allowed size'));
           fileStream.destroy();
         }
       });

--- a/packages/api/src/utility/downloader.js
+++ b/packages/api/src/utility/downloader.js
@@ -1,22 +1,58 @@
 const axios = require('axios');
 const fs = require('fs');
+const { safeHttpAgent, safeHttpsAgent } = require('./safeHttpAgents');
 
-function saveStreamToFile(pipedStream, fileName) {
+// Optional, opt-in limits for hardened (safeRemoteFetch) downloads. Left unset by
+// default so that legitimate imports of large files are not regressed.
+const safeFetchTimeout = parseInt(process.env.EXTERNAL_FETCH_TIMEOUT_MS, 10) || 0;
+const safeFetchMaxBytes = parseInt(process.env.EXTERNAL_FETCH_MAX_BYTES, 10) || 0;
+
+function saveStreamToFile(pipedStream, fileName, maxBytes = 0) {
   return new Promise((resolve, reject) => {
     const fileStream = fs.createWriteStream(fileName);
+    let written = 0;
     fileStream.on('close', () => resolve());
+    fileStream.on('error', reject);
+    pipedStream.on('error', reject);
+    if (maxBytes > 0) {
+      pipedStream.on('data', chunk => {
+        written += chunk.length;
+        if (written > maxBytes) {
+          pipedStream.destroy(new Error('DBGM-00338 Downloaded file exceeds the maximum allowed size'));
+          fileStream.destroy();
+        }
+      });
+    }
     pipedStream.pipe(fileStream);
   });
 }
 
-async function downloadFile(url, file) {
+async function downloadFile(url, file, options = {}) {
   console.log(`Downloading ${url} into ${file}`);
-  const tarballResp = await axios.default({
+  const axiosOptions = {
     method: 'get',
     url,
     responseType: 'stream',
-  });
-  await saveStreamToFile(tarballResp.data, file);
+  };
+  let maxBytes = 0;
+  // safeRemoteFetch is used when the URL originates from a network-exposed,
+  // user-controlled request. It restricts the connection to public hosts and
+  // bounds the number of redirects.
+  if (options.safeRemoteFetch) {
+    axiosOptions.httpAgent = safeHttpAgent;
+    axiosOptions.httpsAgent = safeHttpsAgent;
+    axiosOptions.maxRedirects = 5;
+    // Do not route through an environment proxy (HTTP_PROXY/HTTPS_PROXY): a proxy
+    // would terminate the validated connection and fetch the real target itself,
+    // bypassing the per-connection address checks above.
+    axiosOptions.proxy = false;
+    if (safeFetchTimeout > 0) {
+      axiosOptions.timeout = safeFetchTimeout;
+    }
+    maxBytes = safeFetchMaxBytes;
+  }
+  const tarballResp = await axios.default(axiosOptions);
+  await saveStreamToFile(tarballResp.data, file, maxBytes);
 }
 
 module.exports = {

--- a/packages/api/src/utility/safeHttpAgents.js
+++ b/packages/api/src/utility/safeHttpAgents.js
@@ -44,7 +44,7 @@ function parseAllowedHosts() {
           continue;
         }
       } catch (err) {
-        logger.warn(extractErrorLogData(err), `DBGM-00335 Ignoring invalid entry in EXTERNAL_FETCH_ALLOWED_HOSTS: ${item}`);
+        logger.warn(extractErrorLogData(err), `DBGM-00000 Ignoring invalid entry in EXTERNAL_FETCH_ALLOWED_HOSTS: ${item}`);
         continue;
       }
       hostNames.add(item.toLowerCase());

--- a/packages/api/src/utility/safeHttpAgents.js
+++ b/packages/api/src/utility/safeHttpAgents.js
@@ -57,7 +57,7 @@ const allowedHosts = parseAllowedHosts();
 
 if (allowPrivateNetwork) {
   logger.warn(
-    'DBGM-00336 EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK is enabled - outbound fetch of user-supplied URLs is not protected against SSRF'
+    'DBGM-00000 EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK is enabled - outbound fetch of user-supplied URLs is not protected against SSRF'
   );
 }
 

--- a/packages/api/src/utility/safeHttpAgents.js
+++ b/packages/api/src/utility/safeHttpAgents.js
@@ -1,0 +1,173 @@
+const dns = require('dns');
+const net = require('net');
+const http = require('http');
+const https = require('https');
+const ipaddr = require('ipaddr.js');
+const { getLogger, extractErrorLogData } = require('dbgate-tools');
+
+const logger = getLogger('safeHttpAgents');
+
+// Outbound HTTP(S) hardening for user-supplied URLs (eg. files.downloadText,
+// jsldata.downloadJslData). By default only globally-routable unicast addresses
+// are reachable; loopback, private, link-local, unique-local and other reserved
+// ranges are blocked to prevent SSRF against internal services and cloud
+// metadata endpoints. The target is validated on every socket connection, so
+// redirects and DNS-rebinding are checked per hop.
+//
+// Configuration (all optional):
+//   EXTERNAL_FETCH_ALLOWED_HOSTS         comma/space separated hostnames, IPs or
+//                                        CIDR ranges that are allowed even when
+//                                        they resolve to a non-public address
+//                                        (eg. "intranet.example.com,10.1.0.0/16").
+//   EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK set to "true"/"1" to disable the private
+//                                        network protection entirely. This
+//                                        re-exposes the server to SSRF and should
+//                                        only be used on fully trusted networks.
+
+const allowPrivateNetwork = process.env.EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK == 'true' || process.env.EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK == '1';
+
+function parseAllowedHosts() {
+  const hostNames = new Set();
+  const ipMatchers = [];
+  const raw = process.env.EXTERNAL_FETCH_ALLOWED_HOSTS;
+  if (raw) {
+    for (const itemRaw of raw.split(/[,\s]+/)) {
+      const item = itemRaw.trim();
+      if (!item) continue;
+      try {
+        if (item.includes('/')) {
+          ipMatchers.push({ type: 'cidr', value: ipaddr.parseCIDR(item) });
+          continue;
+        }
+        if (net.isIP(item)) {
+          ipMatchers.push({ type: 'ip', value: ipaddr.parse(item) });
+          continue;
+        }
+      } catch (err) {
+        logger.warn(extractErrorLogData(err), `DBGM-00335 Ignoring invalid entry in EXTERNAL_FETCH_ALLOWED_HOSTS: ${item}`);
+        continue;
+      }
+      hostNames.add(item.toLowerCase());
+    }
+  }
+  return { hostNames, ipMatchers };
+}
+
+const allowedHosts = parseAllowedHosts();
+
+if (allowPrivateNetwork) {
+  logger.warn(
+    'DBGM-00336 EXTERNAL_FETCH_ALLOW_PRIVATE_NETWORK is enabled - outbound fetch of user-supplied URLs is not protected against SSRF'
+  );
+}
+
+function normalizeAddress(ip) {
+  let addr = ipaddr.parse(ip);
+  if (addr.kind() === 'ipv6' && addr.isIPv4MappedAddress()) {
+    addr = addr.toIPv4Address();
+  }
+  return addr;
+}
+
+function isAllowedIp(ip) {
+  let addr;
+  try {
+    addr = normalizeAddress(ip);
+  } catch (err) {
+    return false;
+  }
+  for (const matcher of allowedHosts.ipMatchers) {
+    try {
+      if (matcher.type === 'ip' && addr.toNormalizedString() === matcher.value.toNormalizedString()) {
+        return true;
+      }
+      if (matcher.type === 'cidr' && addr.kind() === matcher.value[0].kind() && addr.match(matcher.value)) {
+        return true;
+      }
+    } catch (err) {
+      // kind mismatch etc. - not a match
+    }
+  }
+  return false;
+}
+
+// An address may be connected to if it is a public unicast address, or it has
+// been explicitly allow-listed by the operator.
+function isAddressAllowed(ip) {
+  if (allowPrivateNetwork) return true;
+  if (isAllowedIp(ip)) return true;
+  try {
+    return normalizeAddress(ip).range() === 'unicast';
+  } catch (err) {
+    // Unparseable address: fail closed.
+    return false;
+  }
+}
+
+function isHostnameAllowlisted(host) {
+  return !!host && allowedHosts.hostNames.has(host.toLowerCase());
+}
+
+function blockedError(target) {
+  return new Error(`DBGM-00337 Blocked request to non-public address ${target}`);
+}
+
+// DNS lookup used for hostname targets. Validates every resolved address.
+function safeLookup(hostname, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) {
+      return callback(err);
+    }
+    const list = Array.isArray(addresses) ? addresses : [addresses];
+    for (const entry of list) {
+      if (!isAddressAllowed(entry.address)) {
+        logger.warn(`DBGM-00337 Blocked request to non-public address ${entry.address} (${hostname})`);
+        return callback(blockedError(`${entry.address} (${hostname})`));
+      }
+    }
+    if (options && options.all) {
+      return callback(null, list);
+    }
+    const chosen = list[0];
+    return callback(null, chosen.address, chosen.family);
+  });
+}
+
+// Build an agent that validates the connection target on every socket creation.
+// Literal-IP targets are checked directly (Node does not invoke `lookup` for
+// them); hostname targets go through safeLookup. createConnection runs for every
+// redirect hop, so each hop is independently validated.
+function makeSafeAgent(BaseAgent) {
+  const agent = new BaseAgent({ keepAlive: false });
+  const baseCreateConnection = agent.createConnection.bind(agent);
+  agent.createConnection = function (options, callback) {
+    const host = options.host || options.hostname;
+    if (host && isHostnameAllowlisted(host)) {
+      return baseCreateConnection(options, callback);
+    }
+    if (host && net.isIP(host) && !isAddressAllowed(host)) {
+      logger.warn(`DBGM-00337 Blocked request to non-public address ${host}`);
+      const err = blockedError(host);
+      if (callback) {
+        callback(err);
+        return;
+      }
+      throw err;
+    }
+    return baseCreateConnection({ ...options, lookup: safeLookup }, callback);
+  };
+  return agent;
+}
+
+const safeHttpAgent = makeSafeAgent(http.Agent);
+const safeHttpsAgent = makeSafeAgent(https.Agent);
+
+module.exports = {
+  safeHttpAgent,
+  safeHttpsAgent,
+  isAddressAllowed,
+};


### PR DESCRIPTION
These endpoints passed a user-supplied URI into download() with no checks: http(s) URLs were fetched unrestricted (SSRF to internal hosts and cloud metadata) and non-http(s) values were read from disk (local file read). Both were reachable unauthenticated in the default deployment.

Restrict these two endpoints to http(s) and managed archive references, and validate the connection target per socket (blocking private and loopback addresses, with proxies disabled). Intranet access can be re-enabled via EXTERNAL_FETCH_ALLOWED_HOSTS.