### PR TITLE
fix: preserve bigint precision in sqlite plugin

### DIFF
--- a/plugins/dbgate-plugin-sqlite/src/backend/driver.libsql.js
+++ b/plugins/dbgate-plugin-sqlite/src/backend/driver.libsql.js
@@ -33,6 +33,7 @@ const libsqlDriver = {
     const client = databaseFile
       ? new Database(databaseFile, { readonly: !!isReadOnly })
       : new Database(databaseUrl, { authToken, readonly: !!isReadOnly });
+    client.defaultSafeIntegers(true);
 
     return {
       client,

--- a/plugins/dbgate-plugin-sqlite/src/backend/driver.sqlite.js
+++ b/plugins/dbgate-plugin-sqlite/src/backend/driver.sqlite.js
@@ -24,6 +24,7 @@ const driver = {
   async connect({ databaseFile, isReadOnly }) {
     const Database = getBetterSqlite();
     const client = new Database(databaseFile, { readonly: !!isReadOnly });
+    client.defaultSafeIntegers(true);
     return {
       client,
     };

--- a/plugins/dbgate-plugin-sqlite/src/backend/helpers.js
+++ b/plugins/dbgate-plugin-sqlite/src/backend/helpers.js
@@ -21,7 +21,7 @@ function runStreamItem(dbhan, sql, options, rowCounter, engine) {
     }
   } else {
     const info = stmt.run();
-    rowCounter.count += info.changes;
+    rowCounter.count += Number(info.changes);
     if (!rowCounter.date) rowCounter.date = new Date().getTime();
     if (new Date().getTime() - rowCounter.date > 1000) {
       options.info({
@@ -47,8 +47,12 @@ async function waitForDrain(stream) {
 
 function modifyRow(row, columns) {
   columns.forEach((col) => {
-    if (row[col.name] instanceof Uint8Array || row[col.name] instanceof ArrayBuffer) {
-      row[col.name] = { $binary: { base64: Buffer.from(row[col.name]).toString('base64') } };
+    const value = row[col.name];
+    if (typeof value === 'bigint') {
+      const parsed = Number(value);
+      row[col.name] = Number.isSafeInteger(parsed) ? parsed : { $bigint: value.toString() };
+    } else if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+      row[col.name] = { $binary: { base64: Buffer.from(value).toString('base64') } };
     }
   });
   return row;


### PR DESCRIPTION
## Description

Fixes #1531

## Problem

SQLite `INTEGER` values larger than `Number.MAX_SAFE_INTEGER` lose precision in the backend JSON response (e.g. `1254071346418286654` → `1254071346418286600`), which also breaks column filters on those values (0 rows returned).

## Screenshots (after fix)

<img width="702" height="523" alt="Screenshot" src="https://github.com/user-attachments/assets/3488c226-6410-491f-9254-abc35cd6af85" />

<img width="697" height="542" alt="Screenshot" src="https://github.com/user-attachments/assets/8df116ed-ff03-4d21-9f4b-d2d796d03091" />

## Root cause

`better-sqlite3` and `libsql` return SQLite `INTEGER` values as JavaScript `number` by default, so values beyond the safe integer range are rounded before DbGate can process them. At least the MongoDB, DuckDB and PostgreSQL plugins already serialize `bigint` values using the existing `{ $bigint: string }` representation.

## Changes

- Enable client.defaultSafeIntegers(true) in both driver.sqlite.js and driver.libsql.js so SQLite INTEGER values are returned as native JavaScript bigint.
- Normalize bigint values in modifyRow(): values within the safe integer range are converted back to number for compatibility, while larger values are serialized as { $bigint: string }.
- Convert info.changes with Number() to preserve the previous behavior and avoid number + bigint TypeError.

## Scope

This PR only changes the SQLite plugin. MongoDB, DuckDB and PostgreSQL already handle `bigint` serialization, and it is unknown whether other plugins emit native `bigint` values. Therefore, this PR is limited to the confirmed affected drivers.

## AI Usage

AI assistance was used for drafting this PR description and reviewing the implementation. All generated code was reviewed and validated before submission.