### PR TITLE
Fix better-sqlite3 architecture in Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,19 @@
+# docker/node_modules is prepared on the runner, so rebuild native code on the target platform.
+FROM node:22-slim AS native-dependencies
+
+WORKDIR /home/dbgate-docker
+
+COPY . .
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    g++ \
+    make \
+    python3 \
+ && npm rebuild better-sqlite3 \
+ && node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.close(); console.log('better-sqlite3 loaded on ' + process.platform + '/' + process.arch)" \
+ && rm -rf /var/lib/apt/lists/*
+
 FROM node:22-slim
 
 LABEL org.opencontainers.image.source="https://github.com/dbgate/dbgate"
@@ -11,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /home/dbgate-docker
 
-COPY . .
+COPY --from=native-dependencies /home/dbgate-docker/ .
 
 RUN ["chmod", "+x", "/home/dbgate-docker/entrypoint.sh"]
 

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,3 +1,17 @@
+# docker/node_modules is prepared on the runner, so rebuild native code on the target platform.
+FROM node:18-alpine AS native-dependencies
+
+WORKDIR /home/dbgate-docker
+
+COPY . .
+
+RUN apk --no-cache add \
+    g++ \
+    make \
+    python3 \
+ && npm rebuild better-sqlite3 \
+ && node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.close(); console.log('better-sqlite3 loaded on ' + process.platform + '/' + process.arch)"
+
 FROM node:18-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/dbgate/dbgate"
@@ -8,7 +22,7 @@ RUN apk --no-cache upgrade \
  && apk --no-cache add  \
     iputils
 
-COPY . .
+COPY --from=native-dependencies /home/dbgate-docker/ .
 
 RUN ["chmod", "+x", "/home/dbgate-docker/entrypoint.sh"]
 


### PR DESCRIPTION
## Summary

- Rebuild `better-sqlite3` in a target-platform build stage for both the Debian and Alpine images.
- Copy the rebuilt application into the final runtime stage, keeping compiler toolchains out of the final images.
- Open an in-memory SQLite database during each platform build, so a wrong-architecture native addon fails the existing multi-arch build immediately.

Related to #653.

## Root cause

`.github/workflows/build-docker.yaml` runs `yarn prepare:docker` on the x86_64 GitHub Actions runner before Docker Buildx starts. `prepare:docker` calls `install:drivers:docker`, which installs `better-sqlite3` and creates:

```
docker/node_modules/better-sqlite3/build/Release/better_sqlite3.node
```

for x86_64.

Buildx subsequently builds `linux/amd64`, `linux/arm64`, and `linux/arm/v7`, but the Dockerfiles only copy that already-prepared directory. A `COPY` does not rebuild native addons, so the ARM images receive the x86-64 ELF.

## Reproduction

On an ARM64 host:

```sh
docker pull --platform linux/arm64 dbgate/dbgate:7.2.5

docker run --rm \
  --platform linux/arm64 \
  --entrypoint node \
  dbgate/dbgate:7.2.5 \
  -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.close()"
```

This fails with `ERR_DLOPEN_FAILED` because the native addon has the wrong architecture.

The addon can also be inspected from the image:

```sh
docker create \
  --platform linux/arm64 \
  --name dbgate-arm64-inspect \
  dbgate/dbgate:7.2.5

docker cp \
  dbgate-arm64-inspect:/home/dbgate-docker/node_modules/better-sqlite3/build/Release/better_sqlite3.node \
  ./better_sqlite3.node

docker rm dbgate-arm64-inspect
file ./better_sqlite3.node
```

Before this change, `file` reports an x86-64 ELF even though the image platform is ARM64.

