### PR TITLE
Support enableCleartextPlugin for MySQL connections

### DIFF
--- a/packages/api/src/utility/envtools.js
+++ b/packages/api/src/utility/envtools.js
@@ -40,6 +40,7 @@ function extractConnectionsFromEnv(env) {
     displayName: env[`LABEL_${id}`],
     mcpEnabled: isTrueValue(env[`MCP_ENABLED_${id}`]),
     isReadOnly: env[`READONLY_${id}`],
+    enableCleartextPlugin: isTrueValue(env[`ENABLE_CLEARTEXT_PLUGIN_${id}`]),
     databases: env[`DBCONFIG_${id}`] ? safeJsonParse(env[`DBCONFIG_${id}`]) : null,
     allowedDatabases: env[`ALLOWED_DATABASES_${id}`]?.replace(/\|/g, '\n'),
     allowedDatabasesRegex: env[`ALLOWED_DATABASES_REGEX_${id}`],

--- a/packages/web/src/settings/ConnectionDriverFields.svelte
+++ b/packages/web/src/settings/ConnectionDriverFields.svelte
@@ -527,6 +527,17 @@
   />
 {/if}
 
+{#if driver?.showConnectionField('enableCleartextPlugin', $values, showConnectionFieldArgs)}
+  <FormCheckboxField
+    label={_t('connection.enableCleartextPlugin', {
+      defaultMessage: 'Enable cleartext password plugin (needed for PAM/LDAP auth)',
+    })}
+    name="enableCleartextPlugin"
+    disabled={isConnected || isFormReadOnly}
+    data-testid="ConnectionDriverFields_enableCleartextPlugin"
+  />
+{/if}
+
 {#if showMcpEnabled}
   <FormCheckboxField
     label={_t('connection.mcpEnabled', { defaultMessage: 'Available in MCP server' })}

--- a/plugins/dbgate-plugin-mysql/src/backend/drivers.js
+++ b/plugins/dbgate-plugin-mysql/src/backend/drivers.js
@@ -73,8 +73,20 @@ const drivers = driverBases.map(driverBase => ({
   analyserClass: Analyser,
 
   async connect(props) {
-    const { conid, server, port, user, password, database, ssl, isReadOnly, forceRowsAsObjects, socketPath, authType } =
-      props;
+    const {
+      conid,
+      server,
+      port,
+      user,
+      password,
+      database,
+      ssl,
+      isReadOnly,
+      forceRowsAsObjects,
+      socketPath,
+      authType,
+      enableCleartextPlugin,
+    } = props;
     let awsIamToken = null;
     if (authType == 'awsIam') {
       awsIamToken = await authProxy.getAwsIamToken(props);
@@ -93,6 +105,11 @@ const drivers = driverBases.map(driverBase => ({
       bigNumberStrings: true,
       dateStrings: true,
       infileStreamFactory: path => fs.createReadStream(path),
+      // enableCleartextPlugin: required for PAM/LDAP auth and for our own AWS IAM auth,
+      // which passes the IAM token as a cleartext password (already requires SSL above).
+      // mysql2 >= 3.22.0 disabled the mysql_clear_password plugin by default, so this
+      // needs to be explicitly opted into rather than assumed.
+      enableCleartextPlugin: authType == 'awsIam' ? true : !!enableCleartextPlugin,
       // TODO: test following options
       // multipleStatements: true,
     };

--- a/plugins/dbgate-plugin-mysql/src/frontend/drivers.js
+++ b/plugins/dbgate-plugin-mysql/src/frontend/drivers.js
@@ -162,7 +162,7 @@ const mysqlDialect = {
 const mysqlDriverBase = {
   ...driverBase,
   showConnectionField: (field, values) => {
-    if (['authType', 'user', 'defaultDatabase', 'singleDatabase', 'isReadOnly', 'allowedDatabases', 'allowedDatabasesRegex', 'defaultIsolationLevel'].includes(field)) {
+    if (['authType', 'user', 'defaultDatabase', 'singleDatabase', 'isReadOnly', 'allowedDatabases', 'allowedDatabasesRegex', 'defaultIsolationLevel', 'enableCleartextPlugin'].includes(field)) {
       return true;
     }
 


### PR DESCRIPTION
mysql2 3.22.0 disabled the mysql_clear_password auth plugin by default. That breaks two paths that both rely on it: PAM/LDAP-backed MySQL auth, and DBGate's own AWS IAM auth, which passes the IAM token as a cleartext password over a connection that already requires SSL.

Add a per-connection 'enableCleartextPlugin' toggle, thread it through to the mysql2 connection options, expose it as an
ENABLE_CLEARTEXT_PLUGIN_<id> env var alongside the other per-connection settings, and turn it on automatically when authType is awsIam so existing IAM-auth connections keep working without the user having to discover and flip a new setting.

Fixes #1544